### PR TITLE
Update README and add redirect.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# inferno-framework.github.io
+# Inferno Framework Site
+
+This repository currently exists to redirect users from https://inferno-framework.github.io
+to https://inferno-framework.github.io/inferno-core.
+
+Eventually, it will contain general Inferno Framework information, with the `/inferno-core`
+path dedicated to those developing Inferno Test Kits using the inferno-core gem.
+
+## License
+Copyright 2022 The MITRE Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License. You may obtain a copy of the
+License at
+```
+http://www.apache.org/licenses/LICENSE-2.0
+```
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://inferno-framework.github.io/inferno-core</title>
+<meta http-equiv="refresh" content="0; URL=https://inferno-framework.github.io/inferno-core">


### PR DESCRIPTION
# Summary

Adds redirect to `/inferno-core` and updates README.

# Testing Guidance

No testing possible.  I confirmed that this will not interfere with the existing /inferno-core content, and should just make it so that https://inferno-framework.github.io no longer is a 404.