### PR TITLE
FI-2091 Replaced docker-compose with docker compose

### DIFF
--- a/docs/deployment/database.md
+++ b/docs/deployment/database.md
@@ -18,7 +18,7 @@ walk through setting up Inferno with PostgreSQL.
 
 ### PostgreSQL with Docker
 The easiest way to run a PostgreSQL service is by adding it to the
-`docker-compose` with the rest of Inferno's services. To do so:
+`docker-compose.yml` file with the rest of Inferno's services. To do so:
 * Add `gem 'pg'` to `Gemfile`
 * Add the following entry to `docker-compose.yml`:
 ```yaml

--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -16,7 +16,7 @@ At a minimum, deploying inferno involves the following:
   some other way)
 - run `setup.sh` to pull & build the needed docker images and run database
   migrations
-- run `docker-compose up -d` to start all of the services in the background
+- run `docker compose up -d` to start all of the services in the background
 
 By default, a deployment of Inferno includes the following services:
 


### PR DESCRIPTION
Requirements met for fulfilling ticket [FI-2091](https://oncprojectracking.healthit.gov/support/browse/FI-2091) for this repo.

Let me know if we need to change [database.md#L28](https://github.com/inferno-framework/inferno-framework.github.io/blob/36ef74824d15563e37d94f68da60ca2558f95659/docs/deployment/database.md?plain=1#L28) and similar lines to docker compose -- Since the docker-compose is now a built in under docker compose, I'm not sure it makes sense to say that we are using docker-compose here, but wasn't fully sure.

