### PR TITLE
FI-2033 Minor typo and grammar fixes

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -25,7 +25,7 @@ libraries. See [Writing Tests](/docs/writing-tests/) for more information.
 
 A distributable set of tests and tools built and packaged
 using Inferno to help testers evaluate the conformance of a system to
-FHIR-based specification requirements, relevant FHIR Implementation
+base FHIR specification requirements, relevant FHIR Implementation
 Guides, and any additional requirements. Test Kits are primarily composed of one
 or more Test Suites, but may include other tools such as FHIR resource validators
 or reference implementations.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -52,7 +52,7 @@ third-party validators (e.g. HL7 FHIR Validator).
 
 ## Reference Implementations
 
-An Inferno Test Kit may provide one or more Reference Implementations, which
+An Inferno Test Kit may provide one or more reference implementations, which
 is a program that implements all requirements from a specification (e.g. FHIR) 
 and demonstrates "correct" behavior. They can
 be useful to develop tests against or to help interact with third-party

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -10,7 +10,7 @@ section: docs
 
 Inferno Core is the primary library of Inferno, which testers can use to build Inferno Test
 Kits. It provides the main logic of Inferno, as well as a CLI, a web
-interface for executing tests, and integration with data persistence layers and 3rd
+interface for executing tests, and integration with data persistence layers and third-party
 party validators. Conceptually, Inferno Core is similar to Ruby on Rails or
 React + create-react-app.
 
@@ -25,7 +25,7 @@ libraries. See [Writing Tests](/docs/writing-tests/) for more information.
 
 A distributable set of tests and tools built and packaged
 using Inferno to help testers evaluate the conformance of a system to
-FHIR base specification requirements, relevant FHIR Implementation
+FHIR-based specification requirements, relevant FHIR Implementation
 Guides, and any additional requirements. Test Kits are primarily composed of one
 or more Test Suites, but may include other tools such as FHIR resource validators
 or reference implementations.
@@ -39,7 +39,7 @@ A template for writing Inferno Test Kits. See [Template Layout](/docs/getting-st
 An executable set of tests provided within an Inferno Test Kit that allows
 testers to evaluate the conformance of a system. They can import tests from other Test Kits. 
 Each Test Suite also defines how to interpret failures at the test level and in aggregate.
-For example, Test Suite may define that a conformant system will pass all provided
+For example, a Test Suite may define that a conformant system will pass all provided
 tests, or that the system may fail some tests. 
 
 ## Validators
@@ -48,14 +48,14 @@ Validators are tools that validate the correctness of a piece of data against a 
 defined within a context. Inferno tests typically fetch data and validate the
 response using a validator, for example the FHIR Profile Validator or the FHIR Terminology
 Validator. Inferno typically performs these functions by providing common
-third party validators (e.g. HL7 FHIR Validator).
+third-party validators (e.g. HL7 FHIR Validator).
 
 ## Reference Implementations
 
 An Inferno Test Kit may provide one or more Reference Implementations, which
 is a program that implements all requirements from a specification (e.g. FHIR) 
-and demonstrates "corect" behavior. They can
-be useful to develop tests against or to help interact with third party
+and demonstrates "correct" behavior. They can
+be useful to develop tests against or to help interact with third-party
 solutions. For example, Inferno has a [Reference Server](https://github.com/inferno-framework/inferno-reference-server)
 for US Core and the Inferno ONC (g)(10) certification tests.
 
@@ -66,4 +66,4 @@ A web host running one or more Inferno Test Kits. An example is the
 An individual Test Kit can also be run as an Inferno Deployment on 
 users' local machines without any additional
 configuration. An Inferno Deployment includes a web interface as well as
-a RESTful API to enable third party integration.
+a RESTful API to enable third-party integration.

--- a/docs/deployment/host.md
+++ b/docs/deployment/host.md
@@ -15,7 +15,7 @@ even though it isn't serving those URLs itself because some tests generate links
 ## Hostname Configuration
 In `.env`, set the `INFERNO_HOST` environment variable to the hostname. 
 This allows Inferno to correctly construct things like
-absolute redirect and launch urls for the SMART App Launch workflow.
+absolute redirect and launch URLs for the SMART App Launch workflow.
 
 ## Base Path Configuration
 If Inferno won't be hosted at the root of its host (e.g., you want to host

--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -11,7 +11,7 @@ Template](https://github.com/inferno-framework/inferno-template). This template
 contains a `docker-compose.yml` file that can run all of the services inferno
 needs.
 
-At a minimum, deploying inferno involves the following:
+At a minimum, deploying Inferno involves the following:
 - `git clone` the repository you want to deploy (or get it onto your server in
   some other way)
 - run `setup.sh` to pull & build the needed docker images and run database

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ section: docs
 
 ## Introduction to Inferno
 Inferno is an application framework for creating, executing, and sharing
-conformance test for FHIR APIs. Inferno tests are packaged within portable test
+conformance tests for FHIR APIs. Inferno tests are packaged within portable test
 applications called <a href="concepts.html#inferno-test-kit">Inferno Test Kits</a>.
 Test Kits are tailored to test specific FHIR-enabled data exchange use cases,
 typically described within one or more [FHIR Implementation
@@ -59,12 +59,12 @@ Creating a test system that is flexible enough to test any arbitrary
 conformance criteria introduced in an IG is challenging.
 Inferno accomplishes this by providing test authors with a full-featured
 Ruby programming environment to define and run tests. It also allows the
-use of the open source third-party libraries provided by Ruby.
+use of the open-source third-party libraries provided by Ruby.
 This makes Inferno well-suited for testing IGs 
 that:
 
 * include additional standards beyond FHIR,
-* have large specifications that could use from Ruby's meta-programming
+* have large specifications that could benefit from Ruby's meta-programming
   capabilities to ease maintenance burden,
 * or require complex logic to thoroughly validate API responses.
 

--- a/index_new.html
+++ b/index_new.html
@@ -26,7 +26,7 @@ layout: base
   <div class="text-center">
     Inferno Framework provides a flexible testing DSL that is tailored to
     the typical needs of conformance testing systems.  You write the tests,
-    and Inferno will provide web, command line, and JSON API for you. 
+    and Inferno will provide web, command line, and JSON APIs for you. 
   </div>
   <pre class="bg-white rounded border-dark"><code class="language-ruby bg-white">test do
   title 'Server returns requested Patient resource from the Patient read interaction'


### PR DESCRIPTION
# Summary
Addressed most of the typo and grammar points from the FI-2033 Documentation Review feedback page.

The only thing I did not know how to fix was the string that appears in the browser tab.  If you go to https://inferno-framework.github.io/index_new.html and look at the tab, it is just "Inferno Framework - " instead of something like "Inferno Framework - Home".  

# Testing Guidance
None
