### PR TITLE
Copy postgres replication note from old docs site

### DIFF
--- a/docs/deployment/database.md
+++ b/docs/deployment/database.md
@@ -64,3 +64,11 @@ use it with the following steps:
 * In `config/database.yml`, change the `adapter` in the `production` entry to
   `postgres`, and supply the `database`, `user`, `password`, `host`, and `port`
   for the PostgreSQL database
+
+**Note**: If you are using replication, for example with AWS RDS, you may
+encounter the error `cannot update table "schema_info" because
+it does not have a replica identity` when first setting up Inferno.
+If this occurs, run the following command in the database:
+```sql
+ALTER TABLE schema_info REPLICA IDENTITY FULL;
+```


### PR DESCRIPTION
# Summary
Copy over a note about DB replication which I guess I didn't realize was on the wrong docs site.
See the bottom of `database.md`  from before it was just deleted: https://github.com/inferno-framework/inferno-core/pull/486/files#diff-be33c680b614ca4ad400108673f732a4d4dab24b6e796c7045a8546354c7d958