### PR TITLE
Fix typo in command line docs

### DIFF
--- a/docs/getting-started/inferno-cli.md
+++ b/docs/getting-started/inferno-cli.md
@@ -5,7 +5,7 @@ parent: Getting Started
 section: docs
 layout: docs
 ---
-# Inferno Command Line Inferface
+# Inferno Command Line Interface
 
 ### Inferno Commands
 The Inferno Command Line Interface is available to developers running Inferno with a local Ruby installation.


### PR DESCRIPTION
# Summary
Fix a minor typo in the documentation for Inferno Command Line Interface

# Testing Guidance
Should say "Interface" instead of "Interface"
