### PR TITLE
Update available fhir methods in documentation.

### DIFF
--- a/docs/writing-tests/making-requests.md
+++ b/docs/writing-tests/making-requests.md
@@ -143,10 +143,14 @@ The following methods are currently available for making FHIR requests:
 - `fhir_create`
 - `fhir_delete`
 - `fhir_get_capability_statement`
+- `fhir_history`
 - `fhir_operation`
+- `fhir_patch`
 - `fhir_read`
 - `fhir_search`
 - `fhir_transaction`
+- `fhir_update`
+- `fhir_vread`
 
 For more details on these methods, see the [FHIR Client API
 documentation](/inferno-core/docs/Inferno/DSL/FHIRClient.html). If you need to


### PR DESCRIPTION
# Summary
Synchronizes [available fhir methods in the documentation site](http://localhost:4000/docs/writing-tests/making-requests.html#fhir-requests) with the [library documentation](https://inferno-framework.github.io/inferno-core/docs/Inferno/DSL/FHIRClient.html).  Caught by Pavel on [Zulip](https://chat.fhir.org/#narrow/stream/179309-inferno/topic/Question.20regarding.20Web.20UI.20for.20multiple.20test.20kits/near/440370998).

# Testing Guidance
I built and served locally and this is what it looks like now:

<img width="610" alt="Screenshot 2024-05-23 at 2 50 15 PM" src="https://github.com/inferno-framework/inferno-framework.github.io/assets/412901/6652fb1f-a91a-4a9d-b228-afbb255deab5">


