### PR TITLE
Update Inferno CLI docs for bundle exec inferno start

### DIFF
--- a/docs/getting-started/inferno-cli.md
+++ b/docs/getting-started/inferno-cli.md
@@ -12,7 +12,7 @@ The Inferno Command Line Interface is available to developers running Inferno wi
 
 We recommend running all commands starting with `bundle exec` (e.g. `bundle exec inferno migrate`) because
 it guarantees that only the specific gems and versions listed in `Gemfile.lock` are available to be used.
-**Exception:** The `inferno start` command cannot be run with `bundle exec`.
+**Warning:** The `inferno start` command cannot be run with `bundle exec` prior to Inferno Core version 0.4.39.
 
 The commands available include:
 


### PR DESCRIPTION
# Summary

This is dependent on inferno-framework/inferno-core#502 getting merged and in being in the next Inferno core release. **Do not merge this until that PR is merged.**

Once we support `bundle exec inferno start` it should no longer be noted as an exemption to the `bundle exec` rule, but I kept it as a warning in case people are using older versions of Inferno. Please advise if there's a better way to handle this.


