### PR TITLE
Add h2 margin, fix header level, condense test kits table, style foot…

### DIFF
--- a/assets/common.css
+++ b/assets/common.css
@@ -222,8 +222,13 @@ footer a:visited {
   color: var(--primary);
 }
 
-.docs-content h1 {
-  padding-bottom: 20px;
+.docs-content {
+  h1 {
+    margin-bottom: 1em;
+  }
+  h2 {
+      margin-top:1em;
+  }
 }
 
 .docs-content .anchor-heading {
@@ -297,8 +302,9 @@ footer a:visited {
 }
 
 .docs-body {
-  max-width: 800px;
+  max-width: 860px;
 }
+
 
 /* Search */
 
@@ -492,12 +498,21 @@ footer a:visited {
 
   td,
   th {
-    padding-left: 7px;
+    padding-left: 0.5em;
+    padding-right: 0.5em;
+    vertical-align:top;
   }
-
+  td {
+    padding-bottom:1em;
+  }
   td:last-child,
-  th:last-child {
+  th:last-child,
+  td:nth-child(2),
+  th:nth-child(2) {
     border-left: 1px solid var(--border);
+    & a {
+      white-space:nowrap;
+    }
   }
 }
 
@@ -539,4 +554,10 @@ footer a:visited {
   th:nth-child(2) {
     border-left: 1px solid var(--border);
   }
+}
+
+.footnotes {
+  border-top:1px solid var(--border);
+  margin-top:2em;
+  padding-top:1em;
 }

--- a/community/test-kits.md
+++ b/community/test-kits.md
@@ -12,26 +12,26 @@ The Test Kit Registry includes all Test Kits currently registered with the Infer
 If you are interested in adding your Test Kit to this table, [Contact Us](/about/who.html)
 or open a [Pull Request](https://github.com/inferno-framework/inferno-framework.github.io/blob/main/community/test-kits.md).
 
-| Test Kit      | Source Code | Public Host |
-|---------------|-------------|-------------|
-| ONC Certification (g)(10) Standardized API Test Kit | [GitHub Repository](https://github.com/onc-healthit/onc-certification-g10-test-kit) &emsp; | [Hosted by ONC](https://inferno.healthit.gov) |
-| At-Home In-Vitro Test Kit | [GitHub Repository](https://github.com/inferno-framework/at-home-in-vitro-test-kit) | [Hosted by ONC](https://inferno.healthit.gov) |
-| Bulk Data Access Test Kit | [Github Repository](https://github.com/inferno-framework/bulk-data-test-kit) | [Hosted by ONC](https://inferno.healthit.gov) |
-| CARIN IG for Blue Button® Test Kit | [GitHub Repository](https://github.com/inferno-framework/carin-for-blue-button-test-kit) | [Hosted by ONC](https://inferno.healthit.gov) |
-| Da Vinci Coverage Requirements Discovery (CRD) Test Kit | [Github Repository](https://github.com/inferno-framework/davinci-crd-test-kit) | [Hosted by ONC](https://inferno.healthit.gov) |
-| Da Vinci Documentation Templates and Rules (DTR) Test Kit | [Github Repository](https://github.com/inferno-framework/davinci-dtr-test-kit) | [Hosted by ONC](https://inferno.healthit.gov) |
-| Da Vinci Payer Data Exchange (PDex) Test Kit | [Github Repository](https://github.com/inferno-framework/davinci-pdex-test-kit) | [Hosted by ONC](https://inferno.healthit.gov) |
-| DaVinci Plan Net Test Kit | [Github Repository](https://github.com/inferno-framework/davinci-plan-net-test-kit) | [Hosted by ONC](https://inferno.healthit.gov) |
-| Da Vinci Prior Authorization Support (PAS) Test Kit | [Github Repository](https://github.com/inferno-framework/davinci-pas-test-kit) | [Hosted by ONC](https://inferno.healthit.gov) |
-| DaVinci US Drug Formulary Test Kit | [Github Repository](https://github.com/inferno-framework/davinci-us-drug-formulary-test-kit) | [Hosted by ONC](https://inferno.healthit.gov) |
-| FAST Security Test Kit | [GitHub Repository](https://github.com/inferno-framework/fast-security-test-kit) | [Hosted by ONC](https://inferno.healthit.gov) |
-| International Patient Access Test Kit | [GitHub Repository](https://github.com/inferno-framework/ipa-test-kit) | [Hosted by ONC](https://inferno.healthit.gov) |
-| International Patient Summary Test Kit | [GitHub Repository](https://github.com/inferno-framework/ips-test-kit) | [Hosted by ONC](https://inferno.healthit.gov) |
-| Service Base URL Test Kit | [Github Repository](https://github.com/inferno-framework/service-base-url-test-kit) | [Hosted by ONC](https://inferno.healthit.gov) |
-| SMART App Launch Test Kit | [GitHub Repository](https://github.com/inferno-framework/smart-app-launch-test-kit) | [Hosted by ONC](https://inferno.healthit.gov) |
-| SMART Health Cards: Vaccination & Testing Test Kit &emsp; | [GitHub Repository](https://github.com/inferno-framework/shc-vaccination-test-kit) | [Hosted by ONC](https://inferno.healthit.gov) |
-| SMART Scheduling Links Test Kit | [GitHub Repository](https://github.com/inferno-framework/smart-scheduling-links-test-kit) | [Hosted by ONC](https://inferno.healthit.gov) |
-| TLS Test Kit | [GitHub Repository](https://github.com/inferno-framework/tls-test-kit) | N/A |
-| UDS+ Test Kit | [GitHub Repository](https://github.com/inferno-framework/uds-plus-test-kit) | [Hosted by ONC](https://inferno.healthit.gov) |
-| US Core Test Kit | [GitHub Repository](https://github.com/inferno-framework/us-core-test-kit) | [Hosted by ONC](https://inferno.healthit.gov) |
-{: .multi-grid}
+| Test Kit Source Code | Public Host |
+|----------------------|-------------|
+| [ONC Certification (g)(10) Standardized API Test Kit](https://github.com/onc-healthit/onc-certification-g10-test-kit) | [Hosted by ONC](https://inferno.healthit.gov) |
+| [At-Home In-Vitro Test Kit](https://github.com/inferno-framework/at-home-in-vitro-test-kit) | [Hosted by ONC](https://inferno.healthit.gov) |
+| [Bulk Data Access Test Kit](https://github.com/inferno-framework/bulk-data-test-kit) | [Hosted by ONC](https://inferno.healthit.gov) |
+| [CARIN IG for Blue Button® Test Kit](https://github.com/inferno-framework/carin-for-blue-button-test-kit) | [Hosted by ONC](https://inferno.healthit.gov) |
+| [Da Vinci Coverage Requirements Discovery (CRD) Test Kit](https://github.com/inferno-framework/davinci-crd-test-kit) | [Hosted by ONC](https://inferno.healthit.gov) |
+| [Da Vinci Documentation Templates and Rules (DTR) Test Kit](https://github.com/inferno-framework/davinci-dtr-test-kit) | [Hosted by ONC](https://inferno.healthit.gov) |
+| [Da Vinci Payer Data Exchange (PDex) Test Kit](https://github.com/inferno-framework/davinci-pdex-test-kit) | [Hosted by ONC](https://inferno.healthit.gov) |
+| [DaVinci Plan Net Test Kit](https://github.com/inferno-framework/davinci-plan-net-test-kit) | [Hosted by ONC](https://inferno.healthit.gov) |
+| [Da Vinci Prior Authorization Support (PAS) Test Kit](https://github.com/inferno-framework/davinci-pas-test-kit) | [Hosted by ONC](https://inferno.healthit.gov) |
+| [DaVinci US Drug Formulary Test Kit](https://github.com/inferno-framework/davinci-us-drug-formulary-test-kit) | [Hosted by ONC](https://inferno.healthit.gov) |
+| [FAST Security Test Kit](https://github.com/inferno-framework/fast-security-test-kit) | [Hosted by ONC](https://inferno.healthit.gov) |
+| [International Patient Access Test Kit](https://github.com/inferno-framework/ipa-test-kit) | [Hosted by ONC](https://inferno.healthit.gov) |
+| [International Patient Summary Test Kit](https://github.com/inferno-framework/ips-test-kit) | [Hosted by ONC](https://inferno.healthit.gov) |
+| [Service Base URL Test Kit](https://github.com/inferno-framework/service-base-url-test-kit) | [Hosted by ONC](https://inferno.healthit.gov) |
+| [SMART App Launch Test Kit](https://github.com/inferno-framework/smart-app-launch-test-kit) | [Hosted by ONC](https://inferno.healthit.gov) |
+| [SMART Health Cards: Vaccination & Testing Test Kit](https://github.com/inferno-framework/shc-vaccination-test-kit) | [Hosted by ONC](https://inferno.healthit.gov) |
+| [SMART Scheduling Links Test Kit](https://github.com/inferno-framework/smart-scheduling-links-test-kit) | [Hosted by ONC](https://inferno.healthit.gov) |
+| [TLS Test Kit](https://github.com/inferno-framework/tls-test-kit) | N/A |
+| [UDS+ Test Kit](https://github.com/inferno-framework/uds-plus-test-kit) | [Hosted by ONC](https://inferno.healthit.gov) |
+| [US Core Test Kit](https://github.com/inferno-framework/us-core-test-kit) | [Hosted by ONC](https://inferno.healthit.gov) |
+{: .grid}

--- a/docs/getting-started/repo-layout-and-organization.md
+++ b/docs/getting-started/repo-layout-and-organization.md
@@ -6,7 +6,7 @@ parent: Getting Started
 section: docs
 layout: docs
 ---
-## Template Layout
+# Template Layout
 After cloning the [template repository](https://github.com/inferno-framework/inferno-template), you will have a directory structure that
 looks something like this:
 ```


### PR DESCRIPTION
# Summary
Add styling for footnotes. 
Condense Test Kits table, align cells to top to improve look when table is narrow
Add extra margin-top for h2 elements in docs
Bump max size of doc-body to 860px

# Testing Guidance
See footnote at /community/index.html
view /community/test-kits.html table, observe behavior when resized
Confirm /docs/getting-started/repo-layout-and-organization.html has h1 as top element
