### PR TITLE
Adjust anchor link icons so user can copy url

### DIFF
--- a/assets/common.css
+++ b/assets/common.css
@@ -226,29 +226,47 @@ footer a:visited {
   padding-bottom: 20px;
 }
 
+/* Styles for Anchor link icon when hovering over headers */
+.docs-content h2:has(> a.anchor-heading),
+.docs-content h3:has(> a.anchor-heading),
+.docs-content h4:has(> a.anchor-heading) {margin-left:-1em;padding-left:1em}
+
 .docs-content .anchor-heading {
-  position: absolute;
-  right: -1rem;
-  width: 1.5rem;
-  padding: 0 0.25rem;
-  overflow: visible
+  position: relative;
+  overflow: visible;
 }
 
-@media (min-width: 50rem) {
+@media (min-width: 881px) {
   .docs-content .anchor-heading {
     right: auto;
-    left: -1rem
+    left: -1.5rem;
+  }
+}
+@media (max-width: 880px) {
+  .docs-content {
+    h2, h3, h4 {
+      margin-left:0;
+      padding-left:0;
+      display:flex;
+      flex-direction:row-reverse;
+      justify-content:flex-end;
+    }
+    .anchor-heading {
+      position:relative;
+      right:-0.25rem;
+    }
   }
 }
 
 .docs-content .anchor-heading svg {
   display: inline-block;
   position: absolute;
-  width: 75%;
+  width: 1.25rem;
   top: 11px;
   color: var(--primary);
   visibility: hidden;
   opacity: 0.4;
+  &:hover {opacity: 0.8}
 }
 
 .docs-content h2 .anchor-heading svg {
@@ -256,7 +274,7 @@ footer a:visited {
 }
 
 .docs-content h3 .anchor-heading svg {
-  top: 9px;
+  top: 6px;
 }
 
 .docs-content h4 .anchor-heading svg {


### PR DESCRIPTION
# Summary
Icon is shown when hovering over h2-h5 header elements in docs, but was positioned such that user couldn't mouse over and copy the link. This fixes that behavior.
It also keeps the link positioned next to the header when resizing the window. If the windows shrinks < 881px, then the icon is moved to the right side of the header element, since there is no longer enough margin on the left to show the icon.

# Testing Guidance
View documentation pages, and hover over header elements (h2-h5 only) 
Red URL icon should appear next to the header. Move the mouse over the icon and verify you can copy the URL for that fragment.
Resize the window < 880px and > 880px and note the behavior of the icon. Verify it is accessible by mouse in both cases (you can hover on the icon and copy the url)
