### PR TITLE
Doc updates for FI-2854

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -4,7 +4,7 @@
       <div class="col-sm-6">
         <h1 data-toc-skip class="h4">Contact Us</h1>
           <p>The fastest way to reach the Inferno team is via the <a
-              href="https://chat.fhir.org/#narrow/stream/179309-inferno">Inferno Zulip stream</a>.</p>
+              href="https://chat.fhir.org/#narrow/stream/179309-inferno">Inferno Chat on Zulip</a>.</p>
           <p>You can also e-mail the <a href="mailto:inferno@groups.mitre.org">Inferno Development Team</a>.</p>
       </div>
       <div class="col-sm-6">

--- a/about/who.md
+++ b/about/who.md
@@ -11,8 +11,7 @@ Coordinator for Health IT (ONC) in support of the ONC Certified Health IT Progra
 Development is currently led by the MITRE Corporation, a not-for-profit organization working in the
 public interest.
 
-The fastest way to reach the Inferno team is via the [Inferno Zulip
-stream](https://chat.fhir.org/#narrow/stream/179309-inferno).
+The fastest way to reach the Inferno team is via the [Inferno Chat on Zulip](https://chat.fhir.org/#narrow/stream/179309-inferno).
 
 You can also
 [e-mail the team](mailto:inferno@groups.mitre.org).

--- a/community/add-ons.md
+++ b/community/add-ons.md
@@ -24,5 +24,6 @@ Note that these may require additional effort to integrate into Test Kits.
 * **[Inferno FHIR Validator App](https://github.com/inferno-framework/fhir-validator-app)**:
   Simple FHIR Validation Web UI that allows users to validate resources against the base
   FHIR specification or FHIR Implementation Guides ([hosted example](https://inferno.healthit.gov/validator)).
-* **[Inferno FHIR Wrapper](https://github.com/inferno-framework/fhir-validator-wrapper)**:  Simple service UI to the HL7 FHIR Validator that Inferno Test Kits
+* **[Inferno FHIR Wrapper](https://github.com/inferno-framework/fhir-validator-wrapper)**:  Simple service UI to the [official HL7 FHIR validation
+  library](https://github.com/hapifhir/org.hl7.fhir.core/tree/master/org.hl7.fhir.validation) that Inferno Test Kits
   use to provide FHIR validation services to Inferno Tests.

--- a/community/hosts.md
+++ b/community/hosts.md
@@ -12,5 +12,7 @@ All known Public Hosts of Inferno Test Kits are listed below. If you are interes
 | Name   | Link   | Host Organization |
 |--------|--------|-------------------|
 | Inferno on HealthIT.gov | [inferno.healthit.gov](https://inferno.healthit.gov) | ONC |
-| Inferno on HealthIT.gov QA | [inferno-qa.healthit.gov](https://inferno-qa.healthit.gov) &emsp; | ONC |
+| Inferno on HealthIT.gov QA[^1] | [inferno-qa.healthit.gov](https://inferno-qa.healthit.gov) | ONC |
 {: .multi-grid}
+
+[^1]: Inferno QA is a site used for testing pre-release versions of Inferno and Test Kits and is **not** for certification use. 

--- a/community/index.md
+++ b/community/index.md
@@ -13,8 +13,8 @@ under the Apache 2.0 license and the source is available in the [Inferno Framewo
 
 ## Inferno Team
 
-The fastest way to reach the Inferno team is via the [Inferno Zulip
-stream](https://chat.fhir.org/#narrow/stream/179309-inferno).
+The fastest way to reach the Inferno team is via the 
+[Inferno Chat on Zulip](https://chat.fhir.org/#narrow/stream/179309-inferno).
 
 You can also
 [e-mail the team](mailto:inferno@groups.mitre.org).
@@ -29,7 +29,7 @@ We welcome feedback on the Test Kits that we have developed[^1], including but n
 - Requirements coverage, such as requirements that have been missed, tests that necessitate features that the IG does not require, or other issues with the interpretation of the IG's requirements.
 - User experience, such as confusing or missing information in the test UI.
 
-Please report any issues on the given Test Kit's Issues page on [our GitHub](https://github.com/inferno-framework).
+Please report any issues on the given Test Kit's Issues page under the [Inferno Framework GitHub Organization](https://github.com/inferno-framework).
 
 ## Contributions
 

--- a/community/inferno-chat.md
+++ b/community/inferno-chat.md
@@ -1,5 +1,5 @@
 ---
-title: Inferno Chat
+title: Inferno Chat on Zulip
 nav_order: 23
 layout: docs
 section: community

--- a/docs/getting-started-users.md
+++ b/docs/getting-started-users.md
@@ -9,8 +9,7 @@ Start here if you're interested in testing a FHIR server against one or more
 existing Test Kits.
 
 ## Running an Existing Test Kit
-Most Test Kits are developed using the [Inferno Template
-repository](https://github.com/inferno-framework/inferno-template), which
+Most Test Kits are developed using the [Inferno Template](https://github.com/inferno-framework/inferno-template) repository, which
 provides scripts for standing up an instance of Inferno to run a selected Test
 Kit. Running a Test Kit usually follows the below steps:
 

--- a/docs/getting-started/debugging.md
+++ b/docs/getting-started/debugging.md
@@ -25,8 +25,7 @@ To use the debug gem:
 ### Example
 {:toc-skip}
 
-We first add the `require 'debug/open_nonstop'` and `debugger` to set a breakpoint. We've added
-these to lines 9 & 10 in the example test below.
+First add the `require 'debug/open_nonstop'` and `debugger` to set a breakpoint. These are shown in lines 9 & 10 in the example test below.
 
 ```ruby
 1  module InfernoTemplate
@@ -50,7 +49,7 @@ these to lines 9 & 10 in the example test below.
 19 end
 ```
 
-We then run the tests until the breakpoint is reached. Then we connect to the debugger console.
+Run the tests until the breakpoint is reached. Then connect to the debugger console.
 
 ```ruby
 ᐅ bundle exec rdbg -A
@@ -68,14 +67,18 @@ DEBUGGER (client): Connected. PID:22112, $0:sidekiq 6.5.7  [0 of 10 busy]
     26|         assert_resource_type(:patient)
     27|         assert resource.id == patient_id,
 ```
-Now you can get information about the current object
+
+In the debugger you can get information about the current object:
+
 ```ruby
 (ruby:remote) self.id
 "test_suite_template-patient_group-Test01"
 (ruby:remote) self.title
 "Server returns requested Patient resource from the Patient read interaction"
 ```
+
 As well as the values of currently defined variables.
+
 ```ruby
 (rdbg:remote) inputs
 [:patient_id, :url, :credentials]
@@ -84,7 +87,9 @@ As well as the values of currently defined variables.
 (rdbg:remote) url
 "https://inferno.healthit.gov/reference-server/r4"
 ```
+
 You can also look at available methods and instance variables of a given object, like `request`
+
 ```ruby
 (rdbg:remote) ls request
 Inferno::Entities::Request
@@ -94,15 +99,18 @@ Inferno::Entities::Request
   verb=
 instance variables: @created_at  @direction  @headers  @id  @index  @name  @request_body  @response_body  @result_id  @status  @test_session_id  @updated_at  @url  @verb
 ```
+
 And then use that as a reference to get additional information:
+
 ```ruby
 (ruby:remote) request.status
 200
 (ruby:remote) request.response_body
 "{\n  \"resourceType\": \"Patient\" ... }"
 ```
+
 There are a lot more commands available than just the ones stated above.
-You can always type `help` for the list of all commands, or `help [COMMAND]` for information about a specific command. 
+Type `help` for the list of all commands, or `help [COMMAND]` for information about a specific command. 
 
 ## Interactive Console
 
@@ -112,7 +120,7 @@ syntax highlighting, runtime invocation, source & documentation browsing, and mo
 the environment generally, as opposed to using the debug gem to review the environment at a specific breakpoint while
 running the system.
 
-For example, I can look at the Suite class that is defined in the Inferno Template by default (`lib/inferno_template.rb`) and
+For example, you can look at the Suite class that is defined in the Inferno Template by default (`lib/inferno_template.rb`) and
 set it to the variable `suite`.
 
 ```ruby
@@ -121,7 +129,7 @@ set it to the variable `suite`.
 => [#<InfernoTemplate::Suite @id="test_suite_template", @title="Inferno Test Suite Template">]
 ```
 
-And then use that variable to see what groups will be run in the suite, which I see are the Capability Statement and Patient Tests.
+And then use that variable to see what groups will be run in the suite, which are the Capability Statement and Patient Tests.
 
 ```ruby
 [2] pry(main)> suite.groups
@@ -129,7 +137,7 @@ And then use that variable to see what groups will be run in the suite, which I 
  #<InfernoTemplate::PatientGroup @id="test_suite_template-patient_group", @short_id="2", @title="Patient  Tests">]
 ```
 
-I can also even see which test will be run first.
+You can also even see which test will be run first.
 
 ```ruby
 [3] pry(main)> suite.groups.first.tests

--- a/docs/getting-started/repo-layout-and-organization.md
+++ b/docs/getting-started/repo-layout-and-organization.md
@@ -7,7 +7,7 @@ section: docs
 layout: docs
 ---
 ## Template Layout
-After cloning the [template repository](https://github.com/inferno-framework/inferno-template), you will have a directory structure that
+After cloning the [Inferno Template](https://github.com/inferno-framework/inferno-template) repository, you will have a directory structure that
 looks something like this:
 ```
 ├── Dockerfile
@@ -78,4 +78,4 @@ lib
 And anyone wanting to use this test kit, would load it with `require
 'us_core_test_kit'`.
 
-If you want more examples, check out the [Community Page](/inferno-core/available-test-kits) to view all available Test Kits.
+If you want more examples, check out the [Community Page](/community/test-kits) to view all available Test Kits currently registered with the Inferno Team.

--- a/docs/index.md
+++ b/docs/index.md
@@ -96,4 +96,4 @@ testing DSL.
   Inferno's Ruby API.
 
 ## Inferno Test Kits
-Visit the [Community Page](/inferno-core/available-test-kits) to view all available Test Kits.
+Visit the [Community Page](/community/test-kits) to view all available Test Kits currently registered with the Inferno Team.


### PR DESCRIPTION
# Summary
Minor fixes for framework doc:
Link "Inferno Template" and include word 'repository' outside link text. 
Update Introduction to clarify 'all available Test Kits' is referring to those hosted on inferno.healthit.gov, not all test kits on the Test Kit Registry page.
Update Introduction page to clarify the FHIR Validator wrapper is deprecated in favor of HL7 validator wrapper. 
Update "Inferno Add-ons" page to reflect FHIR validator wrapper is deprecated in favor of HL7 validator wrapper
fix link on getting started/template layout to Community Test Kits page
remove use of first person in Debugging page.
Change footer link to "Inferno Zulip stream" to "Inferno Chat on Zulip". Change community resources link from "Inferno Chat" to "Inferno Chat on Zulip"
Add note on Community / Public Inferno Hosts that Inferno-qa is used for testing pre-release versions of Inferno and Test Kits and is not for certification use.


