### PR TITLE
Add documentation of the inferno new command

### DIFF
--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -10,7 +10,9 @@ layout: docs
 # Getting Started Creating a Test Kit
 This page shows you how to create a Test Kit from scratch. We recommend using the 
 [Inferno Template](https://github.com/inferno-framework/inferno-template) repository
-as a starting point, since it includes everything you'll need to get started.
+as a starting point, since it includes everything you'll need to get started. You may
+also [create a new Test Kit](/docs/getting-started/inferno-cli.html#creating-a-new-test-kit) using the Inferno
+Command Line Interface (CLI). 
 
 We encourage beginners to visit the
 [Test Kit Authoring Tutorial](https://github.com/inferno-training/inferno-tutorial/wiki)
@@ -69,9 +71,20 @@ WSL may be having networking issues.  To resolve this, you can follow the steps 
 ### Set Up a New Test Kit
 {:toc-skip}
 
-1. Clone the [Inferno Template](https://github.com/inferno-framework/inferno-template) repository. You can
-   either clone this repository directly, or click the green "Use this template"
-   button to create your own repository based on this one.
+There are two convenient methods to create a new Test Kit. The first is by cloning the 
+[Inferno Template](https://github.com/inferno-framework/inferno-template) repository. This
+method ensures you will always be starting with the latest Test Kit Template. You can
+either clone this repository directly, or click the green "Use this template" button in GitHub
+to create your own repository based on the Inferno Template.
+
+The second method is to use the Inferno Command Line Interface. After installing
+the `inferno_core` gem, run `inferno new TestKitName` to create a new Test Kit
+Template in a directory named `test-kit-name`. See how to [create a new Test
+Kit](/docs/getting-started/inferno-cli.html#creating-a-new-test-kit) using the Inferno CLI for more
+information and options.
+
+1. Create your Test Kit by cloning the [Inferno Template](https://github.com/inferno-framework/inferno-template)
+   or by using the `inferno new` command.
 1. Run `bundle install` to install dependencies.
 1. Run `bundle exec inferno migrate` to set up the database.
 
@@ -102,9 +115,8 @@ WSL may be having networking issues.  To resolve this, you can follow the steps 
 ### Set Up a New Test Kit
 {:toc-skip}
 
-1. Clone the [Inferno Template](https://github.com/inferno-framework/inferno-template) repository. You can
-   either clone this repository directly, or click the green "Use this template"
-   button to create your own repository based on this one.
+1. Create your Test Kit by cloning the [Inferno Template](https://github.com/inferno-framework/inferno-template)
+   or by using the `inferno new` command.
 1. Run `./setup.sh` in the template repository to retrieve the necessary Docker
    images and create a database.
 

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -62,7 +62,7 @@ WSL may be having networking issues.  To resolve this, you can follow the steps 
 1. Install Ruby. It is highly recommended that you install Ruby via a [Ruby
    version
    manager](https://www.ruby-lang.org/en/documentation/installation/#managers).
-1. Run `gem install inferno_core` to install inferno.
+1. Run `gem install inferno_core` to install Inferno.
 1. Run `gem install foreman` to install foreman, which will be used to run the
    Inferno web and worker processes.
 1. Run `gem install rerun` to install rerun, which will be used to enable
@@ -77,9 +77,13 @@ method ensures you will always be starting with the latest Test Kit Template. Yo
 either clone this repository directly, or click the green "Use this template" button in GitHub
 to create your own repository based on the Inferno Template.
 
-The second method is to use the Inferno Command Line Interface. After installing
-the `inferno_core` gem, run `inferno new TestKitName` to create a new Test Kit
-Template in a directory named `test-kit-name`. See how to [create a new Test
+The second method is to use the Inferno Command Line Interface. 
+
+```sh
+gem install inferno_core && inferno new my-test-kit
+```
+
+This will create a new Test Kit Template in a directory named `test-kit-name`. See how to [create a new Test
 Kit](/docs/getting-started/inferno-cli.html#creating-a-new-test-kit) using the Inferno CLI for more
 information and options.
 

--- a/docs/getting-started/inferno-cli.md
+++ b/docs/getting-started/inferno-cli.md
@@ -48,13 +48,20 @@ It will automatically install the necessary Gem files used by Inferno Core and r
 database migrations to bring the database up to date. Run `inferno new --help` for more
 options and examples.
 
+```
+inferno new MyTestKit --author "My Name" --author "My Friend" --implementation-guide hl7.fhir.us.core@6.1.0
+```
+
 Note that this command follows the naming convention used by Ruby gems. The command
 `inferno new MyTestKit` will create a new folder named `my-test-kit`. Inside the 
 `my-test-kit/lib` folder, it will create the subdirectory `my_test_kit` for your test files, 
 and the main Ruby file named `my_test_kit.rb`. The main module in the `.rb` file will be named `MyTestKit`.
 
-In `my-test-kit/spec`, it will create the subdirectory `my_test_kit` and in the main `patient_group_spec.rb` RSpec file, it sets the module name to `MyTestKit::PatientGroup`.
+The new test kit supports [RSpec](https://rspec.info/) testing on the test kit itself. It also includes a working example in `my-test-kit/spec/patient_group_spec.rb`.
 
-It will create a `my_test_kit.gemspec` file, and set the names of any authors supplied using the `-a` option, and set the name, summary and description values to your Test Kit name.
+It will create a `my_test_kit.gemspec` file, and set the names of any authors supplied 
+using the `-a` option, and set the name, summary and description values to your Test Kit name. 
+You should manually inspect this file if you want to [publish or distribute the Test Kit](/docs/distributing-tests.html).
 
 
+The `--implementation-guide` or `-i` option will look at an absolute file path if its prefixed by `file:///` or lookup the name in the [official FHIR package registry](https://packages.fhir.org/).

--- a/docs/getting-started/inferno-cli.md
+++ b/docs/getting-started/inferno-cli.md
@@ -9,10 +9,9 @@ layout: docs
 
 # Inferno Command Line Interface
 
-## Inferno Commands
-{:toc-skip}
-
 The Inferno Command Line Interface is available to developers running Inferno with a local Ruby installation.
+
+## Inferno Commands
 
 We recommend running all commands starting with `bundle exec` (e.g. `bundle exec inferno migrate`) because
 it guarantees that only the specific gems and versions listed in `Gemfile.lock` are available to be used.
@@ -25,10 +24,37 @@ The commands available include:
 | `inferno console` | Starts an interactive console session with Inferno. More information can be found on the [Debugging Page](debugging.html#interactive-console). |
 | `inferno help [COMMAND]` | Describes the available commands, or one specific command if specified |
 | `inferno migrate` | Runs database migrations |
+| `inferno new TEST_KIT_NAME` | Create a new test kit. Run `inferno new --help` for additional options. |
 | `inferno services start` | Starts the background services (nginx, Redis, etc.) for Inferno |
 | `inferno services stop` | Stops the background services for Inferno |
 | `inferno start` | Starts Inferno |
-| `inferno suite SUBCOMMAND ...ARGS` | Performs suite-based operations. The available subcommands are `describe`, `help`, and `input_template`.|
+| `inferno suite SUBCOMMAND [...ARGS]` | Performs suite-based operations. The available subcommands are `describe`, `help`, and `input_template`.|
 | `inferno suite help SUBCOMMAND` | View details on the suite subcommands. |
 | `inferno suites` | Lists available test suites |
 {: .grid.command-table}
+
+## Creating a new Test Kit
+
+The `inferno new` command allows you to create a new instance of an Inferno Test
+Kit. This command provides options to specify the names of authors, and load
+required implementation guides locally or from external websites. This will set
+the names of the test folder and Ruby file in the `lib` folder to match the name
+of the test kit, and set the name of the main module. It will also download
+the `package.tgz` file for the specified Implementation Guide(s).
+
+This method can be more convenient than manually cloning the
+[Inferno Template](https://github.com/inferno-framework/inferno-template) repository, as it automatically sets the names of files and folders to match the Test Kit name.  
+It will automatically install the necessary Gem files used by Inferno Core and run the
+database migrations to bring the database up to date. Run `inferno new --help` for more
+options and examples.
+
+Note that this command follows the naming convention used by Ruby gems. The command
+`inferno new MyTestKit` will create a new folder named `my-test-kit`. Inside the 
+`my-test-kit/lib` folder, it will create the subdirectory `my_test_kit` for your test files, 
+and the main Ruby file named `my_test_kit.rb`. The main module in the `.rb` file will be named `MyTestKit`.
+
+In `my-test-kit/spec`, it will create the subdirectory `my_test_kit` and in the main `patient_group_spec.rb` RSpec file, it sets the module name to `MyTestKit::PatientGroup`.
+
+It will create a `my_test_kit.gemspec` file, and set the names of any authors supplied using the `-a` option, and set the name, summary and description values to your Test Kit name.
+
+


### PR DESCRIPTION
Added docs for the `inferno new` command to /docs/getting-started and /docs/getting-started/inferno-cli

# Summary
Now Getting Started mentions using `inferno new` to create Test Kit template as option to cloning. 
Inferno CLI page lists inferno new in the command table and includes paragraphs describing the feature.

# Testing Guidance
Verify links to the Inferno CLI page on the Getting Started page are correct. 
Verify inferno new is in CLI command table
Verify description of using inferno new is correct on CLI page.

