### PR TITLE
FI-2612 Add instructions on importing Test Kits

### DIFF
--- a/docs/writing-tests/index.md
+++ b/docs/writing-tests/index.md
@@ -262,22 +262,55 @@ end
 ```
 
 Test Suites, Groups, Tests and configuration options from the imported Test Kits can be referenced from the imported Test Kit.
+Include the required suite, and then reference test groups with the appropriate id.
 
 ```ruby
-# File: lib/my_custom_test_kit/my_test.rb
+# File: lib/my_custom_test_kit/my_test_suite.rb
+
+require_relative 'ehr_launch_group_stu2'
+require_relative 'app_launch_test'
+
 module MyCustomTestKit
-  class MyEHRLaunchGroup < Inferno::TestGroup
+  class MyEHRLaunchSuite < Inferno::TestSuite
     id :my_kit_smart_ehr_launch
     title 'Custom EHR SMART App Launch'
-    
+      
     run_as_group
     
+    # import entire group
     group from: :smart_ehr_launch_stu2,
       run_as_group: true
-    ...
+    
+    group do
+      title 'My Custom Group'
+      id :my_custom_group
+      
+      # import individual test
+      test from: :smart_app_launch
+      test do
+        title 'Check for response with missing data'
+        ...
+      end
     end
   end
 end
 ```
 
+You can reuse groups and tests in your Test Kit, and customize with your own configuration.
 
+```ruby
+  group from: :smart_discovery_stu2,
+    title 'Custom Group Title'
+    description %(
+      # My Customized group description...
+    )
+    id :my_smart_discovery_group
+    
+    config: {
+      inputs: {
+         url: { name: :bulk_server_url } 
+      }
+    }
+```
+
+            

--- a/docs/writing-tests/index.md
+++ b/docs/writing-tests/index.md
@@ -228,3 +228,72 @@ Note: When importing a group, its optional children can be omitted:
 ```ruby
 group from: :us_core_patient, exclude_optional: true
 ```
+
+## Importing From Other Test Kits
+
+Inferno Test Kits may include other Test Kits as a dependency. This allows you to
+reuse existing tests, test groups or test suites as part of your own tests.  This is helpful
+if your testing requires common functionality already covered by existing Test Kits, such as
+[SMART App Launch](https://github.com/inferno-framework/smart-app-launch-test-kit) for testing 
+connecting to a FHIR Server, and [Bulk Data Access Test Kit](https://github.com/inferno-framework/bulk-data-test-kit) for
+exporting bulk data from a FHIR Server.
+
+To start, add each Test Kit you want to import as a runtime dependency in the `.gemspec` 
+file of your test kit, as you would for additional Ruby gems.
+
+```ruby
+Gem::Specification.new do |spec|
+  spec.name          = 'my_custom_test_kit'
+  spec.version       = '0.0.1'
+  spec.date          = Time.now.utc.strftime('%Y-%m-%d')
+  spec.summary       = 'My Custom Test Kit'
+  spec.description   = 'My custom Inferno test kit for FHIR'
+  spec.license       = 'Apache-2.0'
+  spec.add_runtime_dependency 'inferno_core', '~> 0.4.43'
+
+  # Import additional Test Kits
+  spec.add_runtime_dependency 'smart_app_launch_test_kit', '0.4.5'
+  spec.add_runtime_dependency 'bulk_data_test_kit', '0.10.0'
+    
+  spec.add_development_dependency 'database_cleaner-sequel', '~> 1.8'
+  spec.add_development_dependency 'factory_bot', '~> 6.1'
+  spec.add_development_dependency 'rspec', '~> 3.10'
+  spec.add_development_dependency 'webmock', '~> 3.11'
+  spec.required_ruby_version = Gem::Requirement.new('>= 3.1.2')
+  spec.files = [
+    Dir['lib/**/*.rb'],
+    Dir['lib/**/*.json'],
+    'LICENSE'
+  ].flatten
+
+  spec.require_paths = ['lib']
+end
+```
+
+Then you would add `require` statements for each Test Kit to your main Test Kit Ruby file.
+
+```ruby
+# lib/my_custom_test_kit.rb
+require 'bulk_data_test_kit'
+require 'smart_app_launch_test_kit'
+
+module MyCustomTestKit
+  class MyTestSuite < Inferno::TestSuite
+   ...
+  end
+end
+```
+
+Test Suites, Groups, Tests and configuration options from the imported Test Kits can be referenced using the module name of the imported Test Kit.
+
+```ruby
+# File: lib/my_custom_test_kit/my_test.rb
+module MyCustomTestKit
+  class MyEHRLaunchGroup < SMARTAppLaunch::EHRLaunchGroup
+    title 'Custom EHR SMART App Launch'
+    ...
+  end
+end
+```
+
+

--- a/docs/writing-tests/index.md
+++ b/docs/writing-tests/index.md
@@ -242,32 +242,9 @@ To start, add each Test Kit you want to import as a runtime dependency in the `.
 file of your test kit, as you would for additional Ruby gems.
 
 ```ruby
-Gem::Specification.new do |spec|
-  spec.name          = 'my_custom_test_kit'
-  spec.version       = '0.0.1'
-  spec.date          = Time.now.utc.strftime('%Y-%m-%d')
-  spec.summary       = 'My Custom Test Kit'
-  spec.description   = 'My custom Inferno test kit for FHIR'
-  spec.license       = 'Apache-2.0'
-  spec.add_runtime_dependency 'inferno_core', '~> 0.4.43'
-
   # Import additional Test Kits
   spec.add_runtime_dependency 'smart_app_launch_test_kit', '0.4.5'
   spec.add_runtime_dependency 'bulk_data_test_kit', '0.10.0'
-    
-  spec.add_development_dependency 'database_cleaner-sequel', '~> 1.8'
-  spec.add_development_dependency 'factory_bot', '~> 6.1'
-  spec.add_development_dependency 'rspec', '~> 3.10'
-  spec.add_development_dependency 'webmock', '~> 3.11'
-  spec.required_ruby_version = Gem::Requirement.new('>= 3.1.2')
-  spec.files = [
-    Dir['lib/**/*.rb'],
-    Dir['lib/**/*.json'],
-    'LICENSE'
-  ].flatten
-
-  spec.require_paths = ['lib']
-end
 ```
 
 Then you would add `require` statements for each Test Kit to your main Test Kit Ruby file.
@@ -284,14 +261,21 @@ module MyCustomTestKit
 end
 ```
 
-Test Suites, Groups, Tests and configuration options from the imported Test Kits can be referenced using the module name of the imported Test Kit.
+Test Suites, Groups, Tests and configuration options from the imported Test Kits can be referenced from the imported Test Kit.
 
 ```ruby
 # File: lib/my_custom_test_kit/my_test.rb
 module MyCustomTestKit
-  class MyEHRLaunchGroup < SMARTAppLaunch::EHRLaunchGroup
+  class MyEHRLaunchGroup < Inferno::TestGroup
+    id :my_kit_smart_ehr_launch
     title 'Custom EHR SMART App Launch'
+    
+    run_as_group
+    
+    group from: :smart_ehr_launch_stu2,
+      run_as_group: true
     ...
+    end
   end
 end
 ```


### PR DESCRIPTION
# Summary
Add instructions on importing existing Test Kits to the Writing Tests documentation.

# Testing Guidance
Review /docs/writing-tests for instructions on adding external Test Kits to your Test Kit

