### PR TITLE
FI-3368 Update links to test kit tutorial

### DIFF
--- a/community/resources.md
+++ b/community/resources.md
@@ -12,7 +12,7 @@ section: community
 
 Inferno YouTube Channel: [https://www.youtube.com/@infernoframework](https://www.youtube.com/@infernoframework)
 
-US Core Test Kit Tutorial: [https://github.com/inferno-training/inferno-tutorial/wiki](https://github.com/inferno-training/inferno-tutorial/wiki)
+Inferno Test Kit Authoring Tutorial: [https://github.com/inferno-framework/tutorial-test-kit/wiki](https://github.com/inferno-framework/tutorial-test-kit/wiki)
 
 ## Monthly Tech Talk Presentations
 

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -15,7 +15,7 @@ also [create a new Test Kit](/docs/getting-started/inferno-cli.html#creating-a-n
 Command Line Interface (CLI). 
 
 We encourage beginners to visit the
-[Test Kit Authoring Tutorial](https://github.com/inferno-training/inferno-tutorial/wiki)
+[Inferno Test Kit Authoring Tutorial](https://github.com/inferno-framework/tutorial-test-kit/wiki)
 that walks you through creating a basic set of tests for servers that target a common
 Implementation Guide.
 


### PR DESCRIPTION
# Summary
Inferno Test Kit authoring Tutorial has moved from inferno-training to inferno-framework project.
Update links in getting started and community resources pages.

# Testing Guidance
Verify links now point to GitHub.com/inferno-framework/tutorial-test-kit/wiki
