### PR TITLE
FI-2864 Add link to edit page in github.

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,3 +1,4 @@
+<br/>
 <footer class="py-4 mt-4 bg-light">
   <div class="container-fluid">
     <div class="row">

--- a/_includes/suggest_an_edit.html
+++ b/_includes/suggest_an_edit.html
@@ -1,0 +1,4 @@
+<div class="suggest-improvement">
+  <p><b>Suggest an improvement</b></p>
+  <p>Want to make an change? <a href="https://github.com/inferno-framework/inferno-framework.github.io/blob/main/{{ include.content }}">Contribute an edit</a> for this page on the <a href="https://github.com/inferno-framework/inferno-framework.github.io">Inferno Framework</a> GitHub repository.</p>
+</div>

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -21,15 +21,15 @@
 
 <body data-spy="scroll" data-target="#toc" class="d-flex flex-column  h-100">
   <a href="#content" class="visually-hidden-focusable">Skip to main content</a>
+  <div class="layout-grid">
+    {% include menubar.html %}
 
-  {% include menubar.html %}
+    <main>
+      {{ content }}
+    </main>
 
-  <main>
-    {{ content }}
-  </main>
-
-  {% include footer.html %}
-
+    {% include footer.html %}
+  </div>
   <div class="search-overlay"></div>
 
   <!-- jQuery first, then Popper.js, then Bootstrap JS -->

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -35,6 +35,7 @@ layout: base
     <div class="col-lg-7 order-1">
       <div class="docs-body mx-auto" id="content">
         {% include anchor_headings.html html=content h_min=2 beforeHeading="true" anchorBody="<svg viewBox=\"0 0 16 16\" aria-hidden=\"true\"><use xlink:href=\"#svg-link\"></use></svg>" anchorClass="anchor-heading" anchorAttrs="aria-labelledby=\"%html_id%\"" %}
+        {% include suggest_an_edit.html content=page.path %}
       </div>
     </div>
   </div>

--- a/assets/common.css
+++ b/assets/common.css
@@ -18,6 +18,12 @@ html {
   line-height: 1.2;
 }
 
+.layout-grid {
+  display:grid;
+  min-height: 100dvh;
+  grid-template-rows: auto auto 1fr auto;
+}
+
 code {
   font-size: 0.8rem;
 }
@@ -577,6 +583,16 @@ footer a:visited {
   th:last-child {
     border-left: 1px solid var(--border);
   }
+}
+
+.suggest-improvement {
+  font-size: 0.8em;
+  border-top: 1px solid var(--border);
+  margin-top: 2em;
+  padding-top: 0.5em;
+}
+.suggest-improvement p {
+  margin:0.25rem 0.5rem;
 }
 
 .footnotes {


### PR DESCRIPTION
# Summary
Add a link to the bottom of documentation pages which let's users go directly to the corresponding page in GitHub so they can add edits or changes.

# Testing Guidance
Visit documentation pages and look for the link at the bottom of the page. Verify it takes you to the specific page in the GitHub repository to edit that content.

Bonus - Footer now pinned to bottom of page, regardless of page height.
