### PR TITLE
FI-3277 Bring forward updates from minor_updates branch

### DIFF
--- a/docs/advanced-test-features/configuration-checks.md
+++ b/docs/advanced-test-features/configuration-checks.md
@@ -1,6 +1,6 @@
 ---
 title: Configuration Checks
-nav_order: 5
+nav_order: 6
 parent: Advanced Features
 layout: docs
 section: docs

--- a/docs/advanced-test-features/custom-banner.md
+++ b/docs/advanced-test-features/custom-banner.md
@@ -1,6 +1,6 @@
 ---
 title: Custom Banner
-nav_order: 14
+nav_order: 7
 parent: Advanced Features
 layout: docs
 section: docs

--- a/docs/advanced-test-features/index.md
+++ b/docs/advanced-test-features/index.md
@@ -11,6 +11,10 @@ Now that you've gone through the basics of how to write tests, we can move on to
 These pages do not have to be read in order. Feel free to jump around to whatever pages are useful for your 
 specific use case:
 
+## [Input Presets](/docs/advanced-test-features/input-presets.html)
+Input presets are sets of predefined input values for a suite. Users can select
+a preset to use predefined values without having to manually enter them.
+
 ## [Altering Test Behavior](/docs/advanced-test-features/test-configuration.html)
 This page walks through two options of how
 to alter test behavior at either boot time or at session creation time, to address use

--- a/docs/advanced-test-features/input-presets.md
+++ b/docs/advanced-test-features/input-presets.md
@@ -1,9 +1,9 @@
 ---
 title: Input Presets
-nav_order: 5
-parent: Deploying to Shared Hosts
-section: docs
+nav_order: 1
+parent: Advanced Features
 layout: docs
+section: docs
 ---
 # Input Presets
 Input presets are sets of predefined input values for a suite. Users can select

--- a/docs/advanced-test-features/scratch.md
+++ b/docs/advanced-test-features/scratch.md
@@ -1,6 +1,6 @@
 ---
 title: Scratch
-nav_order: 4
+nav_order: 5
 parent: Advanced Features
 layout: docs
 section: docs

--- a/docs/advanced-test-features/serving-http-requests.md
+++ b/docs/advanced-test-features/serving-http-requests.md
@@ -1,6 +1,6 @@
 ---
 title: Serving HTTP Requests
-nav_order: 2
+nav_order: 3
 parent: Advanced Features
 layout: docs
 section: docs

--- a/docs/advanced-test-features/test-configuration.md
+++ b/docs/advanced-test-features/test-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Altering Test Behavior
-nav_order: 1
+nav_order: 2
 parent: Advanced Features
 layout: docs
 section: docs

--- a/docs/advanced-test-features/waiting-for-requests.md
+++ b/docs/advanced-test-features/waiting-for-requests.md
@@ -1,6 +1,6 @@
 ---
 title: Waiting for Incoming Request
-nav_order: 3
+nav_order: 4
 parent: Advanced Features
 layout: docs
 section: docs

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -9,10 +9,10 @@ section: docs
 ## Inferno Core
 
 Inferno Core is the primary library of Inferno, which testers can use to build Inferno Test
-Kits. It provides the main logic of Inferno, as well as a CLI, a web
+Kits. It provides the main logic of Inferno, as well as a command line interface (CLI), a web
 interface for executing tests, and integration with data persistence layers and third-party
-party validators. Conceptually, Inferno Core is similar to Ruby on Rails or
-React + create-react-app.
+party validators. Conceptually, Inferno Core is similar to [Ruby on Rails](https://rubyonrails.org/) or
+[React](https://react.dev/) + [create-react-app](https://create-react-app.dev/).
 
 {% include figure.html 
     file="inferno-core.png"
@@ -49,7 +49,7 @@ or reference implementations.
 
 ## Inferno Template
 
-Inferno Template is a template for writing Inferno Test Kits. See [Template Layout](/docs/getting-started/repo-layout-and-organization) for more information.
+The Inferno Template is a template for writing Inferno Test Kits. See [Template Layout](/docs/getting-started/repo-layout-and-organization) for more information.
 
 {% include figure.html 
     file="inferno-template.png"
@@ -83,11 +83,10 @@ Inferno Test Kits support using custom or third-party validators, if necessary. 
 
 ## Reference Implementations
 
-An Inferno Test Kit may provide one or more reference implementations, which
-is a program that implements all requirements from a specification (e.g. FHIR) 
-and demonstrates "correct" behavior. They can
-be useful to develop tests against or to help interact with third-party
-solutions. For example, Inferno has a [Reference Server](https://github.com/inferno-framework/inferno-reference-server)
+Reference implementations are example servers that implement all requirements from a
+specification (e.g. FHIR) and demonstrates "correct" behavior. They can be useful to
+develop tests against or to help interact with third-party solutions. For example, Inferno
+has a [Reference Server](https://github.com/inferno-framework/inferno-reference-server)
 for US Core and the Inferno ONC (g)(10) certification tests.
 
 ## Inferno Deployment
@@ -96,7 +95,9 @@ An Inferno Deployment is a web host running one or more Inferno Test Kits. An ex
 [https://inferno.healthit.gov](https://inferno.healthit.gov) website.
 An individual Test Kit can also be run as an Inferno Deployment on 
 users' local machines without any additional
-configuration. An Inferno Deployment includes a web interface as well as
+configuration. See
+[Using Test Kits: Getting Started](/docs/getting-started-users.html)
+for more information. An Inferno Deployment includes a web interface as well as
 a RESTful API to enable third-party integration.
 
 {% include figure.html 

--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -27,7 +27,7 @@ By default, a deployment of Inferno includes the following services:
 - `worker` - The inferno web process which executes the tests
 - `redis` - Message broker that handles communication between the inferno web and worker
   processes
-- `validator_service` - A [JSON API wrapper](https://github.com/inferno-framework/fhir-validator-wrapper) 
+- `validator_service` - A [JSON API wrapper](https://github.com/hapifhir/org.hl7.fhir.validator-wrapper) 
   around the HL7 FHIR validator which Inferno uses to validate FHIR resources
 - `fhir_validator_app` - (Optional) A [web front end](https://github.com/inferno-framework/fhir-validator-app) for the validator
   service which allows users to easily perform standalone FHIR resource validation. Nothing depends

--- a/docs/getting-started-users.md
+++ b/docs/getting-started-users.md
@@ -63,9 +63,9 @@ require 'us_core_test_kit'
 ```
 
 Inferno relies on external validation services for profile validation; by
-default, Inferno uses the [FHIR Validator
-Wrapper](https://github.com/inferno-framework/fhir-validator-wrapper). For Test
-Kits that require profile validation, such as the US Core Test Kit, the
+default, Inferno uses the [HL7 Validator Wrapper](https://github.com/hapifhir/org.hl7.fhir.validator-wrapper). 
+
+For Test Kits that require profile validation, such as the US Core Test Kit, the
 corresponding Implementation Guide needs to be placed in the
 `lib/inferno_deployment/igs/` directory as a _.tgz_ file (i.e., _package.tgz_).
 Inferno Test Kits already have the IGs in their repository,

--- a/docs/index.md
+++ b/docs/index.md
@@ -83,6 +83,11 @@ testing DSL.
 - [Inferno Template](https://github.com/inferno-framework/inferno-template) - A
   template for test writers. This is the repository to use if you want to write
   your own set of tests with Inferno.
+- [FHIR Validator App](https://github.com/inferno-framework/fhir-validator-app) - A
+  simple web wrapper around the [official HL7 FHIR validation
+  library](https://github.com/hapifhir/org.hl7.fhir.core/tree/master/org.hl7.fhir.validation).
+  Inferno relies on this service to validate FHIR resources.
+
 
 ## Documentation Resources
 - [JSON API Documentation](/inferno-core/api-docs) - The documentation for

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,7 +30,7 @@ the <a href="getting-started-users.html">Using Test Kits</a> documentation.
 
 A Test Kit is a standalone Ruby application that can be run on an end
 user's machine, on a shared private host behind a firewall, or on a shared
-public host such as [inferno.healthit.gov](https://inferno.healthit.gov/suites).
+public host such as [inferno.healthit.gov](https://inferno.healthit.gov/test-kits/).
 It is built with the [**Inferno Core**](https://github.com/inferno-framework/inferno-core) gem, which provides
 several useful features for a FHIR testing application, including:
 
@@ -83,11 +83,6 @@ testing DSL.
 - [Inferno Template](https://github.com/inferno-framework/inferno-template) - A
   template for test writers. This is the repository to use if you want to write
   your own set of tests with Inferno.
-- [FHIR Validator
-  Wrapper](https://github.com/inferno-framework/fhir-validator-wrapper) - A
-  simple web wrapper around the [official HL7 FHIR validation
-  library](https://github.com/hapifhir/org.hl7.fhir.core/tree/master/org.hl7.fhir.validation).
-  Inferno relies on this service to validate FHIR resources.
 
 ## Documentation Resources
 - [JSON API Documentation](/inferno-core/api-docs) - The documentation for

--- a/docs/writing-tests/properties.md
+++ b/docs/writing-tests/properties.md
@@ -297,7 +297,7 @@ docs](/inferno-core/docs/Inferno/Entities/TestSuite.html#links-class_method)
 **Description**: Define a summary to display on the suite options
 selection page. If the suite has no options, the summary is not used. If no
 suite summary is defined, the description will be displayed on the options
-selection page.
+selection page. [Markdown](https://commonmark.org/help/) is supported.
 
 **Can Be Used In**: `Suite`
 


### PR DESCRIPTION
# Summary
Some documentation edits from the minor_updates branch were left unmerged. This PR brings forward the documentation updates which are still relevant. https://github.com/inferno-framework/inferno-framework.github.io/pull/37 can be closed after this is merged.

# Testing Guidance
Review language updates on Documentation Introduction and Key Concepts pages.
Advanced Features has brought forward Input Presets to be the first topic.

Getting Started no longer refers to the deprecated FHIR Validator wrapper.
Deploying to shared hosts points to HL7 Wrapper repository.

