### PR TITLE
FI-3442 execute cli docs

### DIFF
--- a/docs/advanced-test-features/using-test-kits-in-ci-cd.md
+++ b/docs/advanced-test-features/using-test-kits-in-ci-cd.md
@@ -15,7 +15,7 @@ CI/CD pipelines. The generic steps around automatically running a Test Kit are:
  2. Obtain your target Test Kit version and make it your working directory
  3. Launch background Inferno services: `bundle exec inferno services start`. This
 command works on top of docker compose and daemonizes the processes for you.
- 4. Confirm that background services, possibly with the [wait-for](https://github.com/eficode/wait-for) script.
+ 4. Confirm that background services are ready, possibly with the [wait-for](https://github.com/eficode/wait-for) script.
  5. Launch your FHIR server and confirm that it is ready to receive requests.
  6. Select the Tests, Test Groups, and Test Suites you want in CI and run them
 with `inferno execute`. See

--- a/docs/advanced-test-features/using-test-kits-in-ci-cd.md
+++ b/docs/advanced-test-features/using-test-kits-in-ci-cd.md
@@ -1,0 +1,34 @@
+---
+title: Using Test Kits in CI/CD
+nav_order: 14
+parent: Advanced Features
+layout: docs
+section: docs
+---
+
+# Using Test Kits in CI/CD
+
+Since inferno execute enables running Inferno tests in CLI, it may be used to construct
+CI/CD pipelines. The generic steps around automatically running a Test Kit are:
+
+ 1. Setup a container or environment with Ruby and Docker
+ 2. Obtain your target Test Kit version and make it your working directory
+ 3. Launch background Inferno services: `bundle exec inferno services start`. This
+command works on top of docker compose and daemonizes the processes for you.
+ 4. Confirm that background services, possibly with the [wait-for](https://github.com/eficode/wait-for) script.
+ 5. Launch your FHIR server and confirm that it is ready to receive requests.
+ 6. Select the Tests, Test Groups, and Test Suites you want in CI and run them
+with `inferno execute`. See
+[Running a Test Kit in Command Line](https://inferno-framework.github.io/docs/getting-started/inferno-cli.html#creating-a-new-test-kit)
+for more information. The command will exit with status 0 if the Inferno Summarizer deems
+it a pass.
+    + You can run multiple inferno execute commands, but remember that each call represents
+its own test session.
+    + Since TLS cannot always be emulated in CI, you can add the environment variable
+`INFERNO_DISABLE_TLS_TEST=true` to mark all TLS tests as omitted and may allow the
+Test Suite to pass.
+ 7. Clean up. You can stop Inferno services with `bundle exec inferno services stop`.
+
+If you want to use GitHub Actions for your CI/CD pipeline, or run the
+ONC Certification (g)(10) Test Kit in CI/CD, you can view our [workflow file](https://github.com/inferno-framework/inferno-reference-server/blob/5e0d06ad5414efa93499fd3de093e29cf5e6d9d1/.github/workflows/inferno_ci.yml)
+on the Inferno Reference Server.

--- a/docs/ci-cd-usage.md
+++ b/docs/ci-cd-usage.md
@@ -10,7 +10,7 @@ section: docs
 Since [inferno
 execute](/docs/getting-started/inferno-cli.html#running-a-test-kit-in-command-line)
 enables running Inferno tests in CLI, it may be used within a Continuous
-Integration or Continuous Deployment (CI/CD) pipelines. The generic steps around
+Integration or Continuous Deployment (CI/CD) pipeline. The generic steps around
 automatically running a Test Kit are:
 
  1. Setup a container or environment with Ruby and Docker

--- a/docs/ci-cd-usage.md
+++ b/docs/ci-cd-usage.md
@@ -1,25 +1,27 @@
 ---
-title: Using Test Kits in CI/CD
-nav_order: 14
-parent: Advanced Features
+title: CI/CD Usage
+nav_order: 26
 layout: docs
 section: docs
 ---
 
 # Using Test Kits in CI/CD
 
-Since inferno execute enables running Inferno tests in CLI, it may be used to construct
-CI/CD pipelines. The generic steps around automatically running a Test Kit are:
+Since [inferno
+execute](/docs/getting-started/inferno-cli.html#running-a-test-kit-in-command-line)
+enables running Inferno tests in CLI, it may be used within a Continuous
+Integration or Continuous Deployment (CI/CD) pipelines. The generic steps around
+automatically running a Test Kit are:
 
  1. Setup a container or environment with Ruby and Docker
  2. Obtain your target Test Kit version and make it your working directory
  3. Launch background Inferno services: `bundle exec inferno services start`. This
 command works on top of docker compose and daemonizes the processes for you.
  4. Confirm that background services are ready, possibly with the [wait-for](https://github.com/eficode/wait-for) script.
- 5. Launch your FHIR server and confirm that it is ready to receive requests.
+ 5. Launch the system under test and confirm that it is ready to receive requests.
  6. Select the Tests, Test Groups, and Test Suites you want in CI and run them
 with `inferno execute`. See
-[Running a Test Kit in Command Line](https://inferno-framework.github.io/docs/getting-started/inferno-cli.html#creating-a-new-test-kit)
+[Running a Test Kit in Command Line](/docs/getting-started/inferno-cli.html#running-a-test-kit-in-command-line)
 for more information. The command will exit with status 0 if the Inferno Summarizer deems
 it a pass.
     + You can run multiple inferno execute commands, but remember that each call represents

--- a/docs/getting-started/inferno-cli.md
+++ b/docs/getting-started/inferno-cli.md
@@ -27,10 +27,11 @@ The commands available include:
 | `inferno new TEST_KIT_NAME` | Create a new test kit. Run `inferno new --help` for additional options. |
 | `inferno services start` | Starts the background services (nginx, Redis, etc.) for Inferno |
 | `inferno services stop` | Stops the background services for Inferno |
-| `inferno start` | Starts Inferno |
+| `inferno start` | Starts Inferno web UI |
 | `inferno suite SUBCOMMAND [...ARGS]` | Performs suite-based operations. The available subcommands are `describe`, `help`, and `input_template`.|
 | `inferno suite help SUBCOMMAND` | View details on the suite subcommands. |
 | `inferno suites` | Lists available test suites |
+| `inferno execute` | Execute tests in the command line instead of web UI |
 {: .grid.command-table}
 
 ## Creating a new Test Kit
@@ -65,3 +66,63 @@ You should manually inspect this file if you want to [publish or distribute the 
 
 
 The `--implementation-guide` or `-i` option will look at an absolute file path if its prefixed by `file:///` or lookup the name in the [official FHIR package registry](https://packages.fhir.org/).
+
+## Running a Test Kit in Command Line
+
+The `inferno execute` command allows you to execute [runnables](https://inferno-framework.github.io/docs/writing-tests/#test-suite-structure)
+from a Test Kit in the shell. The command requires:
+ - the Test Kit as the working directory
+ - Inferno background services running
+ - a Test Suite id
+ - all inputs and any [Suite Options](https://inferno-framework.github.io/docs/advanced-test-features/test-configuration.html#suite-options) necessary for execution
+ - optionally, the short ids of select Tests and Test Groups you want to run
+
+
+For example, to run the [US Core Test Kit](https://github.com/inferno-framework/us-core-test-kit)
+v3.1.1 Single Patient API group, you would:
+
+1. clone the repository
+2. launch the background services with `bundle exec inferno services start`
+3. run the following command
+
+```
+bundle exec inferno execute --suite us_core_v311 \
+                            --suite-options smart_app_launch_version:smart_app_launch_1 \
+                            --groups 2 \
+                            --inputs "url:https://inferno.healthit.gov/reference-server/r4" \
+                                     patient_ids:85,355 \
+                                     "smart_credentials:{\"access_token\":\"SAMPLE_TOKEN\"}"
+```
+
+To view Test Suite ids you can run `bundle exec inferno suites`. Test Group short ids
+and input names are available in the web UI. Suite Option ids and values, if present
+in your Test Kit, can be found in its source code by searching for `suite_option` in the DSL.
+
+The inferno execute command also allows you to execute one or more specific Tests.
+For example, in inferno_core's dev_validator suite you can run exactly two tests via:
+
+```
+bundle exec inferno execute --suite dev_validator --tests 1.01 1.02 --inputs "url:https://hapi.fhir.org/baseR4" patient_id:1234321
+```
+
+You can even combine and repeat Tests and Test Groups by doing:
+
+```
+bundle exec inferno execute --suite dev_validator --short-ids 1 1.01 --inputs "url:https://hapi.fhir.org/baseR4" patient_id:1234321
+```
+
+which means run all Tests under Test Group 1, and after that re-run Test 1.01. Each
+call to `inferno execute` represents one test session, and each short id reflects
+one test run. If short ids are omitted then the entire Test Suite will be executed.
+You can run
+
+```
+bundle exec inferno execute --help
+```
+
+for more information.
+
+Please note that inferno execute is still low maturity and has limitations. Inferno
+currently cannot support SMART launch tests or tests that receive client requests
+via CLI execution. Some tests are also expected to [run as a group](https://inferno-framework.github.io/docs/writing-tests/properties.html#run-as-group),
+and may error or fail erroneously when run individually through CLI.

--- a/docs/getting-started/inferno-cli.md
+++ b/docs/getting-started/inferno-cli.md
@@ -71,11 +71,11 @@ The `--implementation-guide` or `-i` option will look at an absolute file path i
 
 The `inferno execute` command allows you to execute [runnables](https://inferno-framework.github.io/docs/writing-tests/#test-suite-structure)
 from a Test Kit in the shell. The command requires:
- - the Test Kit as the working directory
- - Inferno background services running
- - a Test Suite id
- - all inputs and any [Suite Options](https://inferno-framework.github.io/docs/advanced-test-features/test-configuration.html#suite-options) necessary for execution
- - optionally, the short ids of select Tests and Test Groups you want to run
+ - The Test Kit as the working directory.
+ - Inferno background services running.
+ - A Test Suite id.
+ - All inputs and any [Suite Options](https://inferno-framework.github.io/docs/advanced-test-features/test-configuration.html#suite-options) necessary for execution.
+ - Optionally, the short ids of select Tests and Test Groups you want to run.
 
 
 For example, to run the [US Core Test Kit](https://github.com/inferno-framework/us-core-test-kit)

--- a/docs/writing-tests/properties.md
+++ b/docs/writing-tests/properties.md
@@ -64,6 +64,23 @@ session urls look like `INFERNO_BASE_PATH/TEST_SUITE_ID/TEST_SESSION_ID`.
 docs](/inferno-core/docs/Inferno/DSL/Runnable.html#id-instance_method)
 
 ----
+## Short Id
+**Description**: A short numeric id or sequence number which is displayed
+in the left side of the UI before short title. This attribute is read only
+and is automatically assigned.
+
+**Can Be Used In**: `Test`, `Group`
+
+**Example**:
+```ruby
+require 'us_core_test_kit'
+USCoreTestKit::USCoreV610::USCoreTestSuite.groups.first.short_id  # => "1"
+```
+
+**Reference**: `short_id` in API docs for [Test](https://inferno-framework.github.io/inferno-core/docs/Inferno/Entities/Test.html#short_id-class_method)
+and [TestGroup](https://inferno-framework.github.io/inferno-core/docs/Inferno/Entities/TestGroup.html#short_id-class_method).
+
+----
 ## Description
 **Description**: A detailed description displayed in the UI.
 [Markdown](https://commonmark.org/help/) is supported. The description usually


### PR DESCRIPTION
# Summary

Documentation for `inferno execute`, `short id`, and running test kits in CI/CD. A news update will be a separate PR.

# Testing Guidance

Please review
