### PR TITLE
update distributing tests docs

### DIFF
--- a/docs/distributing-tests.md
+++ b/docs/distributing-tests.md
@@ -12,12 +12,18 @@ make your Test Kit available to others:
 1. Make sure your repository is organized as
 described in [Template Layout](/docs/getting-started/repo-layout-and-organization.html).
 2. Fill out the information in the `gemspec` file at the root of the
-repository. The name of the file should match `spec.name` within the file and
+repository.
+  - The name of the file should match `spec.name` within the file and
 the name of the main file in `lib`. For example, for the US Core Test Kit, this
 file would be named `us_core_test_kit.gempsec` and `spec.name` would be
 `'us_core_test_kit'`. This page has [recommended naming conventions](https://guides.rubygems.org/name-your-gem/)
 for gems.
-3. Create the gem. Run `gem build *.gemspec`. You should see the message `Successfully built RubyGem`. Your Test Kit can be shared by copying the `.gem` file and installing it as you would any other Ruby gem. 
+  - All files that must be packaged into the Ruby gem must be listed in `spec.files`.
+By default a Test Kit uses git to select files from `config/presets` and `lib`.
+  - The line `spec.metadata['inferno_test_kit'] = 'true'` must be present.
+3. Create the gem. Run `gem build *.gemspec`. You should see the message
+`Successfully built RubyGem`. Your Test Kit can be shared by copying the `.gem` file
+and installing it as you would any other Ruby gem.
 4. **Optional:** Once your `gemspec` file has been updated, you can publish your gem
 on [rubygems](https://rubygems.org/), the official Ruby gem repository. This will make
 your Test Kit discoverable and available to the public. To publish your gem on rubygems,


### PR DESCRIPTION
# Summary

Update the distributing tests section of the docs to reflect recent changes in core. This should only be merged after merging inferno-framework/inferno-core#578, releasing the next inferno core version, and releasing a new inferno template.

# Testing Guidance
 1. checkout this branch
 2. `bundle exec jekyll serve`
 3. go to <http://127.0.0.1:4000/docs/distributing-tests.html>
