### PR TITLE
Fix bundle exec start

### DIFF
--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -99,7 +99,7 @@ information and options.
    default, these include nginx, Redis, the FHIR validator service, and the FHIR
    validator UI. You can check to make sure they're running by running `docker container ls` in the
    command line, or checking the "Container" tab in Docker Desktop.
-1. Run `inferno start --watch` to start Inferno and have it reload any time a file
+1. Run `bundle exec inferno start --watch` to start Inferno and have it reload any time a file
    changes. Remove the `watch` flag if you would prefer to manually restart
    Inferno.
 1. Navigate to `http://localhost:4567` to access Inferno. You should see two test groups on the side

--- a/docs/getting-started/inferno-cli.md
+++ b/docs/getting-started/inferno-cli.md
@@ -13,25 +13,25 @@ The Inferno Command Line Interface is available to developers running Inferno wi
 
 ## Inferno Commands
 
-We recommend running all commands starting with `bundle exec` (e.g. `bundle exec inferno migrate`) because
-it guarantees that only the specific gems and versions listed in `Gemfile.lock` are available to be used.
-**Warning:** The `inferno start` command cannot be run with `bundle exec` prior to Inferno Core version 0.4.39.
+All commands (unless stated below) must be prefixed with `bundle exec` (e.g. `bundle exec inferno migrate`) because
+it guarantees that only the exact dependencies listed in `Gemfile.lock` are used.
 
 The commands available include:
 
 | Command      | Description |
 |--------------|-------------|
 | `inferno console` | Starts an interactive console session with Inferno. More information can be found on the [Debugging Page](debugging.html#interactive-console). |
-| `inferno help [COMMAND]` | Describes the available commands, or one specific command if specified |
-| `inferno migrate` | Runs database migrations |
-| `inferno new TEST_KIT_NAME` | Create a new test kit. Run `inferno new --help` for additional options. |
-| `inferno services start` | Starts the background services (nginx, Redis, etc.) for Inferno |
-| `inferno services stop` | Stops the background services for Inferno |
-| `inferno start` | Starts Inferno web UI |
+| `inferno help [COMMAND]` | Describes the available commands, or one specific command if specified. |
+| `inferno migrate` | Runs database migrations. |
+| `inferno new TEST_KIT_NAME` | Create a new test kit. Run `inferno new --help` for additional options. Does not require `bundle exec`. |
+| `inferno services start` | Starts the background services (nginx, Redis, etc.) for Inferno. |
+| `inferno services stop` | Stops the background services for Inferno. |
+| `inferno start` | Starts Inferno web UI. Do not use `bundle exec` if the Inferno Core version is prior to 0.4.39. |
 | `inferno suite SUBCOMMAND [...ARGS]` | Performs suite-based operations. The available subcommands are `describe`, `help`, and `input_template`.|
 | `inferno suite help SUBCOMMAND` | View details on the suite subcommands. |
-| `inferno suites` | Lists available test suites |
-| `inferno execute` | Execute tests in the command line instead of web UI |
+| `inferno suites` | Lists available test suites. |
+| `inferno execute` | Execute tests in the command line instead of web UI. |
+| `inferno version` | Output the version of Inferno Core (not the Test Kit). Does not require `bundle exec`. |
 {: .grid.command-table}
 
 ## Creating a new Test Kit


### PR DESCRIPTION
# Summary

 - Replace `inferno start --watch` with `bundle exec inferno start --watch` in getting started.
 - Update Inferno-CLI docs to be explicit about bundle exec

# Testing Guidance

Please review the diff and this screenshot of the table:

![image](https://github.com/user-attachments/assets/023113aa-d1cb-4b07-b0ce-2a4994a9dc9e)
