### PR TITLE
FI-3780: Update docs to describe skip/omit with blocks

### DIFF
--- a/docs/writing-tests/assertions-and-results.md
+++ b/docs/writing-tests/assertions-and-results.md
@@ -134,6 +134,19 @@ test do
 end
 ```
 
+`skip/omit` can also take a block instead of a message. If an assertion fails
+inside of that block, then the test will skip/omit instead.
+
+```ruby
+test do
+  run do
+    skip do
+      assert false, 'This test will skip rather than fail'
+    end
+  end
+end
+```
+
 ### Adding Messages to Results
 {:toc-skip}
 


### PR DESCRIPTION
# Summary
This branch updates the documentation to describe skip/omit taking blocks.

# Testing Guidance
`bundle exec jekyll s`, then visit `http://localhost:4000/docs/writing-tests/assertions-and-results.html#assigning-specific-results` to see the changes.