### PR TITLE
FI-4030, 4031: Add documentation for the evaluator CLI

### DIFF
--- a/docs/getting-started/inferno-cli.md
+++ b/docs/getting-started/inferno-cli.md
@@ -31,7 +31,7 @@ The commands available include:
 | `inferno suite help SUBCOMMAND` | View details on the suite subcommands. |
 | `inferno suites` | Lists available test suites. |
 | `inferno execute` | Execute tests in the command line instead of web UI. |
-| `inferno evaluate [IG_PATH]` | Run the FHIR evaluator in the command line. Does not require `bundle exec`. |
+| `inferno evaluate IG_PATH [DATA_PATH]` | Run the FHIR evaluator in the command line. Does not require `bundle exec`. |
 | `inferno version` | Output the version of Inferno Core (not the Test Kit). Does not require `bundle exec`. |
 {: .grid.command-table}
 

--- a/docs/getting-started/inferno-cli.md
+++ b/docs/getting-started/inferno-cli.md
@@ -31,7 +31,7 @@ The commands available include:
 | `inferno suite help SUBCOMMAND` | View details on the suite subcommands. |
 | `inferno suites` | Lists available test suites. |
 | `inferno execute` | Execute tests in the command line instead of web UI. |
-| `inferno evaluate [IG_PATH] [DATA_PATH]` | Run the FHIR evaluator in the command line. |
+| `inferno evaluate [IG_PATH]` | Run the FHIR evaluator in the command line. |
 | `inferno version` | Output the version of Inferno Core (not the Test Kit). Does not require `bundle exec`. |
 {: .grid.command-table}
 

--- a/docs/getting-started/inferno-cli.md
+++ b/docs/getting-started/inferno-cli.md
@@ -31,6 +31,7 @@ The commands available include:
 | `inferno suite help SUBCOMMAND` | View details on the suite subcommands. |
 | `inferno suites` | Lists available test suites. |
 | `inferno execute` | Execute tests in the command line instead of web UI. |
+| `inferno evaluate [IG_PATH]` | Run the evaluator in the command line. |
 | `inferno version` | Output the version of Inferno Core (not the Test Kit). Does not require `bundle exec`. |
 {: .grid.command-table}
 

--- a/docs/getting-started/inferno-cli.md
+++ b/docs/getting-started/inferno-cli.md
@@ -132,10 +132,10 @@ and may error or fail erroneously when run individually through CLI.
 
 The Evaluator is a command-line tool that characterizes and analyzes HL7® FHIR® data in the context of a given Implementation Guide. The Evaluator is primarily designed to help ensure example datasets are comprehensive and useful.
 
-To run the Evalutor, install dependencies with `bundle install`. Run the evaluation CLI with bundle exec evaluator evaluate:
+To run the Evaluator, install dependencies with `bundle install`. Run the evaluation CLI with the command below:
 
 ```
-bundle exec evaluator evaluate ig_path [data_path]
+bundle exec inferno evaluate ig_path [data_path]
 ```
 
 For example:
@@ -143,11 +143,11 @@ For example:
 Load the US core IG and evaluate the data in the provided example folder. If there are examples in the IG already, they will be ignored.
 
 ```
-bundle exec evaluator evaluate ./uscore7.0.0.tgz ./package/example
+bundle exec inferno evaluate ./uscore7.0.0.tgz ./package/example
 ```
 
 Loads the US core IG and evaluate the data included in the IG's example folder.
 
 ```
-bundle exec evaluator evaluate ./uscore7.0.0.tgz
+bundle exec inferno evaluate ./uscore7.0.0.tgz
 ```

--- a/docs/getting-started/inferno-cli.md
+++ b/docs/getting-started/inferno-cli.md
@@ -31,7 +31,7 @@ The commands available include:
 | `inferno suite help SUBCOMMAND` | View details on the suite subcommands. |
 | `inferno suites` | Lists available test suites. |
 | `inferno execute` | Execute tests in the command line instead of web UI. |
-| `inferno evaluate [IG_PATH]` | Run the evaluator in the command line. |
+| `inferno evaluate [IG_PATH] [DATA_PATH]` | Run the FHIR evaluator in the command line. |
 | `inferno version` | Output the version of Inferno Core (not the Test Kit). Does not require `bundle exec`. |
 {: .grid.command-table}
 
@@ -127,3 +127,27 @@ Please note that inferno execute is still low maturity and has limitations. Infe
 currently cannot support SMART launch tests or tests that receive client requests
 via CLI execution. Some tests are also expected to [run as a group](https://inferno-framework.github.io/docs/writing-tests/properties.html#run-as-group),
 and may error or fail erroneously when run individually through CLI.
+
+## Run the FHIR Evaluator
+
+The Evaluator is a command-line tool that characterizes and analyzes HL7® FHIR® data in the context of a given Implementation Guide. The Evaluator is primarily designed to help ensure example datasets are comprehensive and useful.
+
+To run the Evalutor, install dependencies with `bundle install`. Run the evaluation CLI with bundle exec evaluator evaluate:
+
+```
+bundle exec evaluator evaluate ig_path [data_path]
+```
+
+For example:
+
+Load the US core IG and evaluate the data in the provided example folder. If there are examples in the IG already, they will be ignored.
+
+```
+bundle exec evaluator evaluate ./uscore7.0.0.tgz ./package/example
+```
+
+Loads the US core IG and evaluate the data included in the IG's example folder.
+
+```
+bundle exec evaluator evaluate ./uscore7.0.0.tgz
+```

--- a/docs/getting-started/inferno-cli.md
+++ b/docs/getting-started/inferno-cli.md
@@ -31,7 +31,7 @@ The commands available include:
 | `inferno suite help SUBCOMMAND` | View details on the suite subcommands. |
 | `inferno suites` | Lists available test suites. |
 | `inferno execute` | Execute tests in the command line instead of web UI. |
-| `inferno evaluate [IG_PATH]` | Run the FHIR evaluator in the command line. |
+| `inferno evaluate [IG_PATH]` | Run the FHIR evaluator in the command line. Does not require `bundle exec`. |
 | `inferno version` | Output the version of Inferno Core (not the Test Kit). Does not require `bundle exec`. |
 {: .grid.command-table}
 
@@ -132,7 +132,7 @@ and may error or fail erroneously when run individually through CLI.
 
 The Evaluator is a command-line tool that characterizes and analyzes HL7® FHIR® data in the context of a given Implementation Guide. The Evaluator is primarily designed to help ensure example datasets are comprehensive and useful.
 
-To run the Evaluator, install dependencies with `bundle install`. Run the evaluation CLI with the command below:
+Run the evaluation CLI with the command below:
 
 ```
 bundle exec inferno evaluate ig_path [data_path]

--- a/docs/writing-tests/fhir-validation.md
+++ b/docs/writing-tests/fhir-validation.md
@@ -139,3 +139,27 @@ fhir_resource_validator do
   end
 end
 ```
+
+# MustSupport Test using the Evaluator
+
+Checking the presence of Must Support elements is a common feature across test kits and
+its implementation has been copy-and-pasted between them. 
+To improve the productivity of developing test kits, the Evaluator CLI is built into 
+inferno core, and the MustSupport checks can also be invoked in the context of a test kit 
+by a single method.
+
+To invoke the MustSupport checks, add the following code into test:
+
+```
+assert_must_support_elements_present(resources, profile_url, metadata)
+```
+
+Refer to the assertion API documentation below:
+
+[assert_must_support_elements_present](https://inferno-framework.github.io/inferno-core/docs/Inferno/DSL/Assertions.html#assert_must_support_elements_present-instance_method)
+
+Refer to the examples used in IGs below:
+
+[CARIN for BlueButton IG Test kit](https://github.com/inferno-framework/carin-for-blue-button-test-kit/blob/main/lib/carin_for_blue_button_test_kit/must_support_test.rb)
+
+[International Patient Summary IG Test kit](https://github.com/inferno-framework/ipa-test-kit/blob/main/lib/ipa_test_kit/must_support_test.rb)


### PR DESCRIPTION
# Summary

Added documentation on using the evaluator CLI to the "Inferno CLI" documentation page. Also added examples to run the evaluator as a sub section.

# Issue

This isn't necessarily the long term home for this documentation since use of the Evaluator may not be in the context of "Creating Test Kits", but we can put it there for now.