### PR TITLE
FI-4229: Update CLI Commands Documentation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -271,6 +271,7 @@ PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
 
 DEPENDENCIES
   github-pages (~> 228)

--- a/docs/getting-started/inferno-cli.md
+++ b/docs/getting-started/inferno-cli.md
@@ -142,13 +142,19 @@ You can use the `inferno suite` command to interact with test suites more granul
 
 - **`input_template SUITE_ID`**
 
-  Generates a YAML template for creating an input preset.
+  Generates a JSON template for creating an input preset for a Test Suite.
 
   **Options**:
-  - `-f`, `--filename <filename>`: Write the template to a specific file.
+  - `-f`, `--filename <filename>`: Write the preset template to a specific file.
 
   ```sh
-  bundle exec inferno suite input_template us_core_v311 -f template.yml
+  bundle exec inferno suite input_template us_core_v311 -f template.json
+  ```
+
+  The file may also include embedded Ruby (`.json.erb`) for dynamic content.
+
+  ```sh
+  bundle exec inferno suite input_template us_core_v311 -f template.json.erb
   ```
 
 - **`lock_short_ids SUITE_ID`**
@@ -175,7 +181,7 @@ Options:
 - `-o`, `--output`: Output result as an OperationOutcome to the specified file (e.g., `outcome.json`).
 - `-c`, `--config`: Use a custom YAML config file to evaluate the data.
 
-### Examples
+**Examples:**
 
 Load the US Core IG and evaluate the data in the provided example folder. If there are examples in the IG already, they will be ignored.
 

--- a/docs/getting-started/inferno-cli.md
+++ b/docs/getting-started/inferno-cli.md
@@ -161,9 +161,19 @@ You can use the `inferno suite` command to interact with test suites more granul
 
   Loads the given suite and writes its current short_id map to its corresponding YAML file.
 
+  Short IDs are numeric identifiers displayed in the left side of the Inferno UI, before short title. By default, Inferno auto-generates these based on test order.
+
+  Locking short IDs ensures that test short IDs remain consistent, even when tests are added, removed, or reordered.
+
+  This is especially useful for certification test kits, like [ONC Certification (g)(10) Standardized API Test Kit](https://github.com/onc-healthit/onc-certification-g10-test-kit), where maintaining stable short IDs is important for usability and traceability.
+
+   **Example usage (from the ONC Certification (g)(10) Standardized API Test Kit):**
+
   ```sh
-  bundle exec inferno suite lock_short_ids us_core_v311
+  bundle exec inferno suite lock_short_ids 'g10_certification'
   ```
+
+  This will persist the current short ID mapping to: `./lib/onc_certification_g10_test_kit/short_id_map.yml`.
 
 ## Run the FHIR Evaluator
 

--- a/docs/getting-started/inferno-cli.md
+++ b/docs/getting-started/inferno-cli.md
@@ -167,6 +167,8 @@ You can use the `inferno suite` command to interact with test suites more granul
 
   This is especially useful for certification test kits, like [ONC Certification (g)(10) Standardized API Test Kit](https://github.com/onc-healthit/onc-certification-g10-test-kit), where maintaining stable short IDs is important for usability and traceability.
 
+  The short ID map is written to: `./lib/<test_kit_name>/<suite_name>_short_id_map.yml`
+
    **Example usage (from the ONC Certification (g)(10) Standardized API Test Kit):**
 
   ```sh

--- a/docs/getting-started/inferno-cli.md
+++ b/docs/getting-started/inferno-cli.md
@@ -173,7 +173,9 @@ You can use the `inferno suite` command to interact with test suites more granul
   bundle exec inferno suite lock_short_ids 'g10_certification'
   ```
 
-  This will persist the current short ID mapping to: `./lib/onc_certification_g10_test_kit/short_id_map.yml`.
+  This will persist the current short ID mapping to: `./lib/onc_certification_g10_test_kit/g10_certification_suite_short_id_map.yml`.
+
+  > **Note**: If a test kit uses locked short IDs, the developer must execute this command whenever tests are added or removed to keep the short ID map up to date.
 
 ## Run the FHIR Evaluator
 

--- a/docs/getting-started/inferno-cli.md
+++ b/docs/getting-started/inferno-cli.md
@@ -27,12 +27,12 @@ The commands available include:
 | `inferno services start` | Starts the background services (nginx, Redis, etc.) for Inferno. |
 | `inferno services stop` | Stops the background services for Inferno. |
 | `inferno start` | Starts Inferno web UI. Do not use `bundle exec` if the Inferno Core version is prior to 0.4.39. |
-| `inferno suite SUBCOMMAND [...ARGS]` | Performs suite-based operations. The available subcommands are `describe`, `help`, and `input_template`.|
+| `inferno suite SUBCOMMAND [...ARGS]` | Performs suite-based operations. The available subcommands are `describe`, `help`, `input_template`, and `lock_short_ids`.|
 | `inferno suite help SUBCOMMAND` | View details on the suite subcommands. |
 | `inferno suites` | Lists available test suites. |
 | `inferno execute` | Execute tests in the command line instead of web UI. |
-| `inferno evaluate IG_PATH [DATA_PATH]` | Run the FHIR evaluator in the command line. Does not require `bundle exec`. |
-| `inferno version` | Output the version of Inferno Core (not the Test Kit). Does not require `bundle exec`. |
+| `inferno evaluate IG_PATH [--options]` | Run the FHIR evaluator in the command line. Does not require `bundle exec`. |
+| `inferno version` | Outputs the version of Inferno Core (not the Test Kit). Does not require `bundle exec`. |
 {: .grid.command-table}
 
 ## Creating a new Test Kit
@@ -45,7 +45,7 @@ of the test kit, and set the name of the main module. It will also download
 the `package.tgz` file for the specified Implementation Guide(s).
 
 This method can be more convenient than manually cloning the
-[Inferno Template](https://github.com/inferno-framework/inferno-template) repository, as it automatically sets the names of files and folders to match the Test Kit name.  
+[Inferno Template](https://github.com/inferno-framework/inferno-template) repository, as it automatically sets the names of files and folders to match the Test Kit name.
 It will automatically install the necessary Gem files used by Inferno Core and run the
 database migrations to bring the database up to date. Run `inferno new --help` for more
 options and examples.
@@ -55,14 +55,14 @@ inferno new MyTestKit --author "My Name" --author "My Friend" --implementation-g
 ```
 
 Note that this command follows the naming convention used by Ruby gems. The command
-`inferno new MyTestKit` will create a new folder named `my-test-kit`. Inside the 
-`my-test-kit/lib` folder, it will create the subdirectory `my_test_kit` for your test files, 
+`inferno new MyTestKit` will create a new folder named `my-test-kit`. Inside the
+`my-test-kit/lib` folder, it will create the subdirectory `my_test_kit` for your test files,
 and the main Ruby file named `my_test_kit.rb`. The main module in the `.rb` file will be named `MyTestKit`.
 
 The new test kit supports [RSpec](https://rspec.info/) testing on the test kit itself. It also includes a working example in `my-test-kit/spec/patient_group_spec.rb`.
 
-It will create a `my_test_kit.gemspec` file, and set the names of any authors supplied 
-using the `-a` option, and set the name, summary and description values to your Test Kit name. 
+It will create a `my_test_kit.gemspec` file, and set the names of any authors supplied
+using the `-a` option, and set the name, summary and description values to your Test Kit name.
 You should manually inspect this file if you want to [publish or distribute the Test Kit](/docs/distributing-tests.html).
 
 
@@ -128,6 +128,37 @@ currently cannot support SMART launch tests or tests that receive client request
 via CLI execution. Some tests are also expected to [run as a group](https://inferno-framework.github.io/docs/writing-tests/properties.html#run-as-group),
 and may error or fail erroneously when run individually through CLI.
 
+## Suite Subcommands
+
+You can use the `inferno suite` command to interact with test suites more granularly.
+
+- **`describe SUITE_ID`**
+
+  Displays a suite's description and available suite options.
+
+  ```sh
+  bundle exec inferno suite describe us_core_v311
+  ```
+
+- **`input_template SUITE_ID`**
+
+  Generates a YAML template for creating an input preset.
+
+  **Options**:
+  - `-f`, `--filename <filename>`: Write the template to a specific file.
+
+  ```sh
+  bundle exec inferno suite input_template us_core_v311 -f template.yml
+  ```
+
+- **`lock_short_ids SUITE_ID`**
+
+  Loads the given suite and writes its current short_id map to its corresponding YAML file.
+
+  ```sh
+  bundle exec inferno suite lock_short_ids us_core_v311
+  ```
+
 ## Run the FHIR Evaluator
 
 The Evaluator is a command-line tool that characterizes and analyzes HL7® FHIR® data in the context of a given Implementation Guide. The Evaluator is primarily designed to help ensure example datasets are comprehensive and useful.
@@ -138,7 +169,13 @@ Run the evaluation CLI with the command below:
 inferno evaluate [-d data_path] ig_path
 ```
 
-For example:
+Options:
+
+- `-d`, `--data-path`: Specify a path to example FHIR data. If not provided, examples embedded in the IG will be used.
+- `-o`, `--output`: Output result as an OperationOutcome to the specified file (e.g., `outcome.json`).
+- `-c`, `--config`: Use a custom YAML config file to evaluate the data.
+
+### Examples
 
 Load the US Core IG and evaluate the data in the provided example folder. If there are examples in the IG already, they will be ignored.
 
@@ -150,4 +187,16 @@ Loads the US Core IG and evaluate the data included in the IG's example folder.
 
 ```
 inferno evaluate ./uscore7.0.0.tgz
+```
+
+Export results as an OperationOutcome to a file:
+
+```
+inferno evaluate ./uscore7.0.0.tgz --output outcome.json
+```
+
+Use a custom configuration file:
+
+```
+inferno evaluate ./uscore7.0.0.tgz --config ./my_config.yml
 ```


### PR DESCRIPTION
# Summary
This PR updates the CLI documentation to add missing implemented commands and options, including:

* Coverage of `evaluate`, `suite describe`, `input_template`, and `lock_short_ids` commands
* Additional evaluator CLI options: `--data-path`, `--output`, `--config`

# Testing Guidance
run `bundle exec jekyll serve` and go to `http://localhost:4000/docs/getting-started/inferno-cli.html` to inspect the changes.
