### PR TITLE
FI-4233: Runnable Child Manipulation and Suite Link Helpers  Documentation

### DIFF
--- a/docs/advanced-test-features/test-configuration.md
+++ b/docs/advanced-test-features/test-configuration.md
@@ -54,7 +54,7 @@ different input.
 class MyTestGroup < Inferno::TestGroup
   input :source_server_url
   input :destination_server_url
-  
+
   # Inline config
   test from: :tls_version_test,
        id: :source_server_tls_test,
@@ -63,7 +63,7 @@ class MyTestGroup < Inferno::TestGroup
            url: { name: :source_server_url }
          }
        }
-       
+
   # Config within test block
   test from: :tls_version_test do
     id :destination_server_tls_test
@@ -162,7 +162,7 @@ Custom configuration options allow information to be loaded at boot time and
 made available to tests. For example, a test could have optional functionality
 which is enabled by setting a specific configuration option value.
 
-[This test](https://github.com/inferno-framework/tls-test-kit/blob/main/lib/tls_test_kit/tls_version_test.rb), 
+[This test](https://github.com/inferno-framework/tls-test-kit/blob/main/lib/tls_test_kit/tls_version_test.rb),
 which checks the TLS versions a server supports,
 allows test authors to set minimum and maximum allowed TLS versions. This
 gives the test flexibility to be used in a variety of different testing
@@ -240,13 +240,13 @@ selected when starting their session.
 class MyTestSuite < Inferno::TestSuite
   # suite_option :smart_app_launch_version,
   # ...
-  
+
   # Suite option requirements can be defined inline
   group from: :smart_app_launch_v1,
         required_suite_options: {
           smart_app_launch_version: 'smart_app_launch_1'
         }
-        
+
   # Suite option requirements can also be defined within a test/group definition
   group from: :smart_app_launch_v2 do
     required_suite_options smart_app_launch_version: 'smart_app_launch_2'
@@ -268,6 +268,71 @@ class MyTest < Inferno::Test
     elsif suite_options[:smart_app_launch_version] == 'smart_app_launch_2'
       # Perform SMART App Launch v2 behavior
     end
+  end
+end
+```
+
+## Manipulating Runnable Children
+
+Inferno supports advanced test suite customization by allowing test kit developers to dynamically modify the children of a runnable (group or suite). This includes reordering, replacing, and removing groups or tests.
+
+These methods are useful when test behavior must adapt to specific testing requirements or configuration contexts.
+They allow fine-grained control over test execution and layout while preserving modular and reusable test definitions.
+
+### Reordering Children
+{:toc-skip}
+
+Move a test or group to a new position within its parent group or suite:
+
+```ruby
+class MyTestSuite < Inferno::TestSuite
+  # ...
+
+  # Move the `standalone_token_tls` test to the first position within the `smart_standalone_launch` group
+  group from: :smart_standalone_launch do
+    reorder :standalone_token_tls, 0
+  end
+end
+```
+
+### Replacing Children
+{:toc-skip}
+
+Replace an existing child test or group with another:
+
+```ruby
+require_relative 'smart_custom_tls_test'
+
+class MyTestSuite < Inferno::TestSuite
+  # --
+
+  # Replace the `standalone_token_tls` test with a custom test
+  group from: :smart_standalone_launch do
+    replace :standalone_token_tls, :smart_custom_tls
+  end
+
+  # Replace the `standalone_token_tls` test with a custom test and passing block for additional configuration
+  group from: :smart_standalone_launch_stu2 do
+    replace :standalone_token_tls, :custom_tls_test do
+      id :customized_tls_check
+      config(inputs: { url: { name: :smart_custom_url } })
+    end
+  end
+end
+```
+
+### Removing Children
+{:toc-skip}
+
+Remove a test or group entirely by ID:
+
+```ruby
+class MyTestSuite < Inferno::TestSuite
+  # ...
+
+  # Remove the `standalone_token_tls` test from the group
+  group from: :smart_standalone_launch do
+    remove :standalone_token_tls
   end
 end
 ```

--- a/docs/writing-tests/properties.md
+++ b/docs/writing-tests/properties.md
@@ -5,6 +5,8 @@ parent: Writing Tests
 layout: docs
 section: docs
 ---
+{:toc-skip: .h4 data-toc-skip=""}
+
 # Test, Group & Suite Properties
 
 ## Title
@@ -311,14 +313,13 @@ end
 **Reference**: [`links` in the API
 docs](/inferno-core/docs/Inferno/DSL/Links.html#links-instance_method)
 
-----
-## add_link / source_code_url / ig_url / download_url / report_issue_url
+### Convenience Link Helpers
+{:toc-skip}
 
-**Description**: Convenience methods to add links to the suite footer.
-
-**Can Be Used In**: `Suite`
+**Description**: Shortcut methods for adding links to the suite footer without needing to define a full hash manually.
 
 **Example**:
+
 ```ruby
 class MyTestSuite < Inferno::TestSuite
   source_code_url 'https://github.com/example/source'
@@ -328,8 +329,8 @@ class MyTestSuite < Inferno::TestSuite
   add_link 'custom', 'Custom Link', 'https://example.com'
 end
 ```
-**Reference**: [`Links DSL` in the API
-docs](/inferno-core/docs/Inferno/DSL/Links.html)
+
+**Reference**: [`Links DSL` in the API docs](/inferno-core/docs/Inferno/DSL/Links.html)
 
 ----
 ## Suite Summary
@@ -361,34 +362,4 @@ docs](/inferno-core/docs/Inferno/Entities/TestSuite.html#suite_summary-class_met
 
 **Reference**: [`config` in the API
 docs](/inferno-core/docs/Inferno/DSL/Configurable.html#config-instance_method)
-
-----
-## Reorder
-**Description**: Move a child test or group to a new position. For more information, see
-[Reordering Children](/docs/advanced-test-features/test-configuration#reordering-children).
-
-**Can Be Used In**: `Suite`, `Group`
-
-**Reference**: [`reorder` in the API
-docs](/inferno-core/docs/Inferno/DSL/Runnable.html#reorder-instance_method)
-
-----
-## Replace
-**Description**: Replace a child test or group with another. For more information, see
-[Replacing Children](/docs/advanced-test-features/test-configuration#replacing-children).
-
-**Can Be Used In**: `Suite`, `Group`
-
-**Reference**: [`replace` in the API
-docs](/inferno-core/docs/Inferno/DSL/Runnable.html#replace-instance_method)
-
-----
-## Remove
-**Description**: Remove a child test or group by ID. For more information, see
-[Removinging Children](/docs/advanced-test-features/test-configuration#removing-children).
-
-**Can Be Used In**: `Suite`, `Group`
-
-**Reference**: [`remove` in the API
-docs](/inferno-core/docs/Inferno/DSL/Runnable.html#remove-instance_method)
 

--- a/docs/writing-tests/properties.md
+++ b/docs/writing-tests/properties.md
@@ -10,7 +10,7 @@ section: docs
 ## Title
 **Description**: The title which is displayed in the UI.
 
-**Can be Used In**: `Test`, `Group`, `Suite` 
+**Can be Used In**: `Test`, `Group`, `Suite`
 
 **Example**:
 ```ruby
@@ -25,7 +25,7 @@ docs](/inferno-core/docs/Inferno/DSL/Runnable.html#title-instance_method)
 ## Short Title
 **Description**: A short title which is displayed in the left side of the UI.
 
-**Can be Used In**: `Test`, `Group`, `Suite` 
+**Can be Used In**: `Test`, `Group`, `Suite`
 
 **Example**:
 ```ruby
@@ -93,15 +93,15 @@ define long strings in Ruby.
 ```ruby
 test do
   description 'This is a brief description'
-  
+
   description 'This is a longer description. There are several ways to split ' \
               'it up over multiple lines, and this is one of the worst ways.'
-              
+
   description <<~DESCRIPTION
     This is another long description. This is an ok way to represent a long
     string in ruby.
   DESCRIPTION
-  
+
   description %(
     This is another long description. This is a pretty good way to represent a
     long string in ruby.
@@ -126,14 +126,14 @@ group do
   test do
     optional # Makes this test optional
   end
-  
+
   test from: :some_optional_test do
     required # Make an optional test required
   end
 end
 ```
 **Reference**: [`optional` in the API
-docs](/inferno-core/docs/Inferno/DSL/Runnable.html#optional-instance_method), 
+docs](/inferno-core/docs/Inferno/DSL/Runnable.html#optional-instance_method),
 [`required` in the API
 docs](/inferno-core/docs/Inferno/DSL/Runnable.html#required-instance_method)
 
@@ -174,7 +174,7 @@ docs](/inferno-core/docs/Inferno/Entities/TestSuite.html#version-class_method)
 
 ----
 ## Input Instructions
-**Description**: 
+**Description**:
 Define additional instructions which will be displayed above a runnable's
 inputs. These instructions only appear when running this particular runnable.
 They will not appear if you run a parent or child of this runnable.
@@ -296,10 +296,12 @@ the UI.
 class MyTestSuite < Inferno::TestSuite
   links [
     {
+      type: 'report_issue',
       label: 'Report Issue',
       url: 'https://github.com/onc-healthit/onc-certification-g10-test-kit/issues/'
     },
     {
+      type: 'source_code',
       label: 'Open Source',
       url: 'https://github.com/onc-healthit/onc-certification-g10-test-kit/'
     }
@@ -307,7 +309,27 @@ class MyTestSuite < Inferno::TestSuite
 end
 ```
 **Reference**: [`links` in the API
-docs](/inferno-core/docs/Inferno/Entities/TestSuite.html#links-class_method)
+docs](/inferno-core/docs/Inferno/DSL/Links.html#links-instance_method)
+
+----
+## add_link / source_code_url / ig_url / download_url / report_issue_url
+
+**Description**: Convenience methods to add links to the suite footer.
+
+**Can Be Used In**: `Suite`
+
+**Example**:
+```ruby
+class MyTestSuite < Inferno::TestSuite
+  source_code_url 'https://github.com/example/source'
+  ig_url 'https://hl7.org/fhir/us/core/'
+  download_url 'https://example.com/download'
+  report_issue_url 'https://github.com/example/issues'
+  add_link 'custom', 'Custom Link', 'https://example.com'
+end
+```
+**Reference**: [`Links DSL` in the API
+docs](/inferno-core/docs/Inferno/DSL/Links.html)
 
 ----
 ## Suite Summary
@@ -339,3 +361,34 @@ docs](/inferno-core/docs/Inferno/Entities/TestSuite.html#suite_summary-class_met
 
 **Reference**: [`config` in the API
 docs](/inferno-core/docs/Inferno/DSL/Configurable.html#config-instance_method)
+
+----
+## Reorder
+**Description**: Move a child test or group to a new position. For more information, see
+[Reordering Children](/docs/advanced-test-features/test-configuration#reordering-children).
+
+**Can Be Used In**: `Suite`, `Group`
+
+**Reference**: [`reorder` in the API
+docs](/inferno-core/docs/Inferno/DSL/Runnable.html#reorder-instance_method)
+
+----
+## Replace
+**Description**: Replace a child test or group with another. For more information, see
+[Replacing Children](/docs/advanced-test-features/test-configuration#replacing-children).
+
+**Can Be Used In**: `Suite`, `Group`
+
+**Reference**: [`replace` in the API
+docs](/inferno-core/docs/Inferno/DSL/Runnable.html#replace-instance_method)
+
+----
+## Remove
+**Description**: Remove a child test or group by ID. For more information, see
+[Removinging Children](/docs/advanced-test-features/test-configuration#removing-children).
+
+**Can Be Used In**: `Suite`, `Group`
+
+**Reference**: [`remove` in the API
+docs](/inferno-core/docs/Inferno/DSL/Runnable.html#remove-instance_method)
+


### PR DESCRIPTION
# Summary
This PR adds documentation for manipulating runnable children (`remove`, `replace`,` reorder`), as well as Suite link helpers (`add_link`, `source_code_url`,` ig_url`, `download_url`, `report_issue_url`).


