### PR TITLE
flag where github workflow puts debugging artifacts

### DIFF
--- a/docs/advanced-test-features/scripting-execution.md
+++ b/docs/advanced-test-features/scripting-execution.md
@@ -50,7 +50,7 @@ where it is not:
   - Compared results for one or more sessions did not match.
   - Script execution reached an unmatched stable state (no action specified for a `done` or `waiting` state).
 - No results comparison performed
-  - The exepected results file for one or more sessions did not exist.
+  - The exepected results file for one or more sessions did not exist and was generated.
   - Script execution had to be interrupted due to a timeout. 
   - The results contained an `error` result, indicating a problem in the test logic
 

--- a/docs/ci-cd-usage.md
+++ b/docs/ci-cd-usage.md
@@ -35,6 +35,19 @@ Key considerations when using this GitHub workflow:
   repository with Inferno's standard Ruby setup. You can modify the workflow if your commands
   require additional setup to execute.
 
+### Investigating github workflow failures
+
+The [standard Github Workflow file](https://github.com/inferno-framework/inferno-template/blob/main/.github/workflows/run_inferno_execution_scripts.yml)
+will output debugging artifacts including
+- The inferno test kit process log
+- Docker container logs
+- Actual result json and comparison analysis csv files
+
+Note that in cases where the script execution does not perform the
+results comparison and no actual result files are generated because
+there was an `error` result in a test, the error will be present
+in the inferno process log for debugging purposes.
+
 ## Using the `inferno execute` CLI for Simple Execution
 
 To run Inferno using the [inferno


### PR DESCRIPTION
# Summary

Actual result files are not written when there are errors, which can cause confusion when encountered in the github workflow because it is unclear how to debug. Add a note that there is information in the inferno process log which is included.

# Testing Guidance

Check the rendered CI/CD page.
